### PR TITLE
Emit deprecation warnings for LiteLLM and LiteLLMRouter integrations (already being maintained as standalone package)

### DIFF
--- a/libs/community/langchain_community/chat_models/litellm.py
+++ b/libs/community/langchain_community/chat_models/litellm.py
@@ -4,8 +4,8 @@ Deprecated LiteLLM wrapper.
 ⭐  Use `pip install langchain-litellm` and import
    `from langchain_litellm import ChatLiteLLM` instead.
 """
+
 from __future__ import annotations
-from langchain_core._api.deprecation import deprecated
 
 import json
 import logging
@@ -25,6 +25,7 @@ from typing import (
     Union,
 )
 
+from langchain_core._api.deprecation import deprecated
 from langchain_core.callbacks import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
@@ -246,6 +247,7 @@ _OPENAI_MODELS = [
     "gpt-4-32k-0314",
     "gpt-4-32k-0613",
 ]
+
 
 @deprecated(
     since="0.3.24",

--- a/libs/community/langchain_community/chat_models/litellm.py
+++ b/libs/community/langchain_community/chat_models/litellm.py
@@ -1,6 +1,11 @@
-"""Wrapper around LiteLLM's model I/O library."""
+"""
+Deprecated LiteLLM wrapper.
 
+⭐  Use `pip install langchain-litellm` and import
+   `from langchain_litellm import ChatLiteLLM` instead.
+"""
 from __future__ import annotations
+from langchain_core._api.deprecation import deprecated
 
 import json
 import logging
@@ -242,9 +247,13 @@ _OPENAI_MODELS = [
     "gpt-4-32k-0613",
 ]
 
-
+@deprecated(
+    since="0.3.24",
+    removal="1.0",
+    alternative_import="langchain_litellm.ChatLiteLLM",
+)
 class ChatLiteLLM(BaseChatModel):
-    """Chat model that uses the LiteLLM API."""
+    """DEPRECATED – use `langchain_litellm.ChatLiteLLM` instead."""
 
     client: Any = None  #: :meta private:
     model: str = "gpt-3.5-turbo"

--- a/libs/community/langchain_community/chat_models/litellm_router.py
+++ b/libs/community/langchain_community/chat_models/litellm_router.py
@@ -4,10 +4,10 @@ Deprecated LiteLLM wrapper.
 ⭐  Use `pip install langchain-litellm` and import
    `from langchain_litellm import ChatLiteLLMRouter` instead.
 """
-from langchain_core._api.deprecation import deprecated
 
 from typing import Any, AsyncIterator, Iterator, List, Mapping, Optional
 
+from langchain_core._api.deprecation import deprecated
 from langchain_core.callbacks.manager import (
     AsyncCallbackManagerForLLMRun,
     CallbackManagerForLLMRun,
@@ -39,6 +39,7 @@ def get_llm_output(usage: Any, **params: Any) -> dict:
             # if token usage in metadata, prefer metadata's copy of it
             llm_output[key] = metadata[key]
     return llm_output
+
 
 @deprecated(
     since="0.3.24",

--- a/libs/community/langchain_community/chat_models/litellm_router.py
+++ b/libs/community/langchain_community/chat_models/litellm_router.py
@@ -1,4 +1,10 @@
-"""LiteLLM Router as LangChain Model."""
+"""
+Deprecated LiteLLM wrapper.
+
+⭐  Use `pip install langchain-litellm` and import
+   `from langchain_litellm import ChatLiteLLMRouter` instead.
+"""
+from langchain_core._api.deprecation import deprecated
 
 from typing import Any, AsyncIterator, Iterator, List, Mapping, Optional
 
@@ -34,9 +40,13 @@ def get_llm_output(usage: Any, **params: Any) -> dict:
             llm_output[key] = metadata[key]
     return llm_output
 
-
+@deprecated(
+    since="0.3.24",
+    removal="1.0",
+    alternative_import="langchain_litellm.ChatLiteLLMRouter",
+)
 class ChatLiteLLMRouter(ChatLiteLLM):
-    """LiteLLM Router as LangChain Model."""
+    """DEPRECATED – use `langchain_litellm.ChatLiteLLMRouter` instead."""
 
     router: Any
 


### PR DESCRIPTION
- [x] LiteLLM is already actively being maintained as a standalone package at https://github.com/Akshay-Dongare/langchain-litellm
- [x] Implemented in accordance to : https://github.com/langchain-ai/langchain/issues/30368