### PR TITLE
Fix the bug that Tool parameter conversion error in ChatTongyi

### DIFF
--- a/libs/community/langchain_community/chat_models/tongyi.py
+++ b/libs/community/langchain_community/chat_models/tongyi.py
@@ -601,11 +601,11 @@ class ChatTongyi(BaseChatModel):
                 if prev_message.get("tool_calls"):
                     prev_function = prev_message["tool_calls"][index]["function"]
 
-                    if hasattr(function, "name"):
+                    if "name" in function:
                         function["name"] = function["name"].replace(
                             prev_function["name"], ""
                         )
-                    if hasattr(function, "arguments"):
+                    if "arguments" in function:
                         function["arguments"] = function["arguments"].replace(
                             prev_function["arguments"], ""
                         )

--- a/libs/community/langchain_community/chat_models/tongyi.py
+++ b/libs/community/langchain_community/chat_models/tongyi.py
@@ -601,12 +601,14 @@ class ChatTongyi(BaseChatModel):
                 if prev_message.get("tool_calls"):
                     prev_function = prev_message["tool_calls"][index]["function"]
 
-                    function["name"] = function["name"].replace(
-                        prev_function["name"], ""
-                    )
-                    function["arguments"] = function["arguments"].replace(
-                        prev_function["arguments"], ""
-                    )
+                    if hasattr(function, "name"):
+                        function["name"] = function["name"].replace(
+                            prev_function["name"], ""
+                        )
+                    if hasattr(function, "arguments"):
+                        function["arguments"] = function["arguments"].replace(
+                            prev_function["arguments"], ""
+                        )
 
         return resp_copy
 


### PR DESCRIPTION
parse the tool parameter information when replying to messages containing tool information.

test information:

test model: qwq-plus

reasoning_content with tools：
{'role': 'assistant', 'content': '', 'reasoning_content': '用户就能通过链接'}
{'role': 'assistant', 'content': '', 'reasoning_content': '直接访问相关功能'}
{'role': 'assistant', 'content': '', 'reasoning_content': '了。'}
{'role': 'assistant', 'content': '', 'tool_calls': [{'index': 0, 'id': 'call_caac3ec7675140c9b8a9db', 'type': 'function', 'function': {'name': 'de3613cd-d705-48b1-9a0a-6a412d4b2590_LoginWithAppSimple', 'arguments': '{"'}}], 'reasoning_content': ''}
{'role': 'assistant', 'content': '', 'tool_calls': [{'index': 0, 'id': '', 'type': 'function', 'function': {'arguments': 'appkey": "'}}], 'reasoning_content': ''}
{'role': 'assistant', 'content': '', 'tool_calls': [{'index': 0, 'id': '', 'type': 'function', 'function': {'arguments': 'appExlink",'}}], 'reasoning_content': ''}
{'role': 'assistant', 'content': '', 'tool_calls': [{'index': 0, 'id': '', 'type': 'function', 'function': {'arguments': ' "resCode":'}}], 'reasoning_content': ''}
{'role': 'assistant', 'content': '', 'tool_calls': [{'index': 0, 'id': '', 'type': 'function', 'function': {'arguments': ' "AqWeb'}}], 'reasoning_content': ''}
{'role': 'assistant', 'content': '', 'tool_calls': [{'index': 0, 'id': '', 'type': 'function', 'function': {'arguments': '"}'}}], 'reasoning_content': ''}
