### PR TITLE
Fix: fallback to api_key if azure_ad_token is empty

### DIFF
--- a/libs/community/langchain_community/retrievers/azure_ai_search.py
+++ b/libs/community/langchain_community/retrievers/azure_ai_search.py
@@ -225,5 +225,3 @@ class AzureCognitiveSearchRetriever(AzureAISearchRetriever):
     This version of the retriever will soon be
     depreciated. Please switch to AzureAISearchRetriever
     """
-
-Fix: use api_key when azure_ad_token is not provided or empty (#31010)

--- a/libs/community/langchain_community/retrievers/azure_ai_search.py
+++ b/libs/community/langchain_community/retrievers/azure_ai_search.py
@@ -175,7 +175,6 @@ class AzureAISearchRetriever(BaseRetriever):
             headers["api-key"] = f"{self.api_key}"
         return headers
 
-
     def _search(self, query: str) -> List[dict]:
         search_url = self._build_search_url(query)
         response = requests.get(search_url, headers=self._headers)

--- a/libs/community/langchain_community/retrievers/azure_ai_search.py
+++ b/libs/community/langchain_community/retrievers/azure_ai_search.py
@@ -169,11 +169,12 @@ class AzureAISearchRetriever(BaseRetriever):
         headers = {
             "Content-Type": "application/json",
         }
-        if not self.azure_ad_token:
+        if self.azure_ad_token:
             headers["Authorization"] = f"Bearer {self.azure_ad_token}"
-        else:
+        elif self.api_key:
             headers["api-key"] = f"{self.api_key}"
         return headers
+
 
     def _search(self, query: str) -> List[dict]:
         search_url = self._build_search_url(query)
@@ -224,3 +225,5 @@ class AzureCognitiveSearchRetriever(AzureAISearchRetriever):
     This version of the retriever will soon be
     depreciated. Please switch to AzureAISearchRetriever
     """
+
+Fix: use api_key when azure_ad_token is not provided or empty (#31010)


### PR DESCRIPTION
Fixes #31010

- Problem: When `azure_ad_token` is empty or not provided, `_headers` incorrectly constructs an empty bearer token.
- Fix: This PR adds a fallback to `api_key` when `azure_ad_token` is empty.
- Based on the community-reported issue and suggestions.

Thanks to @erne2086 and others for highlighting this!
