### PR TITLE
Update firecrawl.py to remove params which are no longer supported in FireCrawl v1 API

### DIFF
--- a/libs/community/langchain_community/document_loaders/firecrawl.py
+++ b/libs/community/langchain_community/document_loaders/firecrawl.py
@@ -272,14 +272,14 @@ class FireCrawlLoader(BaseLoader):
         if self.mode == "scrape":
             firecrawl_docs = [
                 self.firecrawl.scrape_url(
-                    self.url
+                    self.url #TODO: Add FireCrawl v1 API compliant params later
                 )
             ]
         elif self.mode == "crawl":
             if not self.url:
                 raise ValueError("URL is required for crawl mode")
             crawl_response = self.firecrawl.crawl_url(
-                self.url
+                self.url #TODO: Add FireCrawl v1 API compliant params later
             )
             firecrawl_docs = crawl_response.get("data", [])
         elif self.mode == "map":

--- a/libs/community/langchain_community/document_loaders/firecrawl.py
+++ b/libs/community/langchain_community/document_loaders/firecrawl.py
@@ -272,14 +272,14 @@ class FireCrawlLoader(BaseLoader):
         if self.mode == "scrape":
             firecrawl_docs = [
                 self.firecrawl.scrape_url(
-                    self.url, params=self.legacy_scrape_options_adapter(self.params)
+                    self.url
                 )
             ]
         elif self.mode == "crawl":
             if not self.url:
                 raise ValueError("URL is required for crawl mode")
             crawl_response = self.firecrawl.crawl_url(
-                self.url, params=self.legacy_crawler_options_adapter(self.params)
+                self.url
             )
             firecrawl_docs = crawl_response.get("data", [])
         elif self.mode == "map":


### PR DESCRIPTION
The params are no longer supported in the firecrawl v1 api and is throwing an error when using langchain-community library for FireCrawlLoader but is working fine with firecrawl-py.

When trying to run the example snippet from the langchain-community docs it is throwing an error for params.
Code:
```
import dotenv
from langchain_community.document_loaders.firecrawl import FireCrawlLoader

dotenv.load_dotenv()

loader = FireCrawlLoader(
    url = "https://firecrawl.dev",
    mode = "scrape",
)

docs = []
docs_lazy = loader.lazy_load()

# async variant:
# docs_lazy = await loader.alazy_load()

for doc in docs_lazy:
    docs.append(doc)
print(docs[0].page_content[:100])
print(docs[0].metadata)
```

Error:
```
---------------------------------------------------------------------------
HTTPError                                 Traceback (most recent call last)
Cell In[12], line 7
      2 docs_lazy = loader.lazy_load()
      4 # async variant:
      5 # docs_lazy = await loader.alazy_load()
----> 7 for doc in docs_lazy:
      8     docs.append(doc)
      9 print(docs[0].page_content[:100])

File c:\Users\sreekar\AppData\Local\Programs\Python\Python313\Lib\site-packages\langchain_community\document_loaders\firecrawl.py:274, in FireCrawlLoader.lazy_load(self)
    271 def lazy_load(self) -> Iterator[Document]:
    272     if self.mode == "scrape":
    273         firecrawl_docs = [
--> 274             self.firecrawl.scrape_url(
    275                 self.url, params=self.legacy_scrape_options_adapter(self.params)
    276             )
    277         ]
    278     elif self.mode == "crawl":
    279         if not self.url:

File c:\Users\sreekar\AppData\Local\Programs\Python\Python313\Lib\site-packages\firecrawl\firecrawl.py:574, in FirecrawlApp.scrape_url(self, url, formats, include_tags, exclude_tags, only_main_content, wait_for, timeout, location, mobile, skip_tls_verification, remove_base64_images, block_ads, proxy, extract, json_options, actions, change_tracking_options, **kwargs)
    572         raise Exception('Failed to parse Firecrawl response as JSON.')
    573 else:
--> 574     self._handle_error(response, 'scrape URL')

File c:\Users\sreekar\AppData\Local\Programs\Python\Python313\Lib\site-packages\firecrawl\firecrawl.py:2205, in FirecrawlApp._handle_error(self, response, action)
   2202 message = self._get_error_message(response.status_code, action, error_message, error_details)
   2204 # Raise an HTTPError with the custom message and attach the response
-> 2205 raise requests.exceptions.HTTPError(message, response=response)

HTTPError: Unexpected error during scrape URL: Status code 400. Bad Request - [{'code': 'unrecognized_keys', 'keys': ['params'], 'path': [], 'message': 'Unrecognized key in body -- please review the v1 API documentation for request body changes'}]
```