### PR TITLE
Add PMID from PubMedAPIWrapper utility

### DIFF
--- a/libs/community/langchain_community/utilities/pubmed.py
+++ b/libs/community/langchain_community/utilities/pubmed.py
@@ -75,6 +75,7 @@ class PubMedAPIWrapper(BaseModel):
         try:
             # Retrieve the top-k results for the query
             docs = [
+                f"PMID: {result['uid']}\n"
                 f"Published: {result['Published']}\n"
                 f"Title: {result['Title']}\n"
                 f"Copyright Information: {result['Copyright Information']}\n"


### PR DESCRIPTION
The PMID is needed to facilitate functional hyperlink generation.
It is already being fetched as `uid` in line `204`.