### PR TITLE
fix: SurrealDB vectorestore integration

### DIFF
--- a/libs/community/langchain_community/vectorstores/surrealdb.py
+++ b/libs/community/langchain_community/vectorstores/surrealdb.py
@@ -1,10 +1,11 @@
 import asyncio
-from typing import Any, Dict, Iterable, List, Optional, Tuple
+from typing import Iterable, Any, Sequence
 
 import numpy as np
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.vectorstores import VectorStore
+from surrealdb import RecordID
 
 from langchain_community.vectorstores.utils import maximal_marginal_relevance
 
@@ -51,9 +52,9 @@ class SurrealDBStore(VectorStore):
     """
 
     def __init__(
-        self,
-        embedding_function: Embeddings,
-        **kwargs: Any,
+            self,
+            embedding_function: Embeddings,
+            **kwargs: Any,
     ) -> None:
         try:
             from surrealdb import Surreal
@@ -76,20 +77,20 @@ class SurrealDBStore(VectorStore):
         self.embedding_function = embedding_function
         self.kwargs = kwargs
 
-    async def initialize(self) -> None:
+    def initialize(self) -> None:
         """
         Initialize connection to surrealdb database
         and authenticate if credentials are provided
         """
-        await self.sdb.connect()
+        # await self.sdb.connect()
         if "db_user" in self.kwargs and "db_pass" in self.kwargs:
             user = self.kwargs.get("db_user")
             password = self.kwargs.get("db_pass")
-            await self.sdb.signin({"user": user, "pass": password})
-        await self.sdb.use(self.ns, self.db)
+            self.sdb.signin({"username": user, "password": password})
+        self.sdb.use(self.ns, self.db)
 
     @property
-    def embeddings(self) -> Optional[Embeddings]:
+    def embeddings(self) -> Embeddings | None:
         return (
             self.embedding_function
             if isinstance(self.embedding_function, Embeddings)
@@ -97,11 +98,11 @@ class SurrealDBStore(VectorStore):
         )
 
     async def aadd_texts(
-        self,
-        texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
-        **kwargs: Any,
-    ) -> List[str]:
+            self,
+            texts: Iterable[str],
+            metadatas: list[dict] | None = None,
+            **kwargs: Any,
+    ) -> list[str]:
         """Add list of text along with embeddings to the vector store asynchronously
 
         Args:
@@ -113,24 +114,27 @@ class SurrealDBStore(VectorStore):
         embeddings = self.embedding_function.embed_documents(list(texts))
         ids = []
         for idx, text in enumerate(texts):
-            data = {"text": text, "embedding": embeddings[idx]}
+            data = {"text": text, "embedding": embeddings[idx], "metadata": {}}
             if metadatas is not None and idx < len(metadatas):
                 data["metadata"] = metadatas[idx]  # type: ignore[assignment]
-            else:
-                data["metadata"] = []
-            record = await self.sdb.create(
-                self.collection,
-                data,
-            )
-            ids.append(record[0]["id"])
+            preferred_id = data["metadata"].get("id")
+            kwargs_ids = kwargs.get("ids", [])
+            if kwargs_ids and idx < len(kwargs_ids) and kwargs_ids[idx] is not None:
+                preferred_id = kwargs_ids[idx]
+
+            # TODO: consider using insert and make a single bulk insert call, but not if we have IDs in the metadata or
+            #       in kwargs, because only with `create` we can specify IDs
+            record_id = RecordID(self.collection, preferred_id) if preferred_id is not None else self.collection
+            record = self.sdb.upsert(record_id, data)
+            ids.append(record.get("id").id)
         return ids
 
     def add_texts(
-        self,
-        texts: Iterable[str],
-        metadatas: Optional[List[dict]] = None,
-        **kwargs: Any,
-    ) -> List[str]:
+            self,
+            texts: Iterable[str],
+            metadatas: list[dict] | None = None,
+            **kwargs: Any,
+    ) -> list[str]:
         """Add list of text along with embeddings to the vector store
 
         Args:
@@ -141,20 +145,20 @@ class SurrealDBStore(VectorStore):
         """
 
         async def _add_texts(
-            texts: Iterable[str],
-            metadatas: Optional[List[dict]] = None,
-            **kwargs: Any,
-        ) -> List[str]:
-            await self.initialize()
+                texts: Iterable[str],
+                metadatas: list[dict] | None = None,
+                **kwargs: Any,
+        ) -> list[str]:
+            self.initialize()
             return await self.aadd_texts(texts, metadatas, **kwargs)
 
         return asyncio.run(_add_texts(texts, metadatas, **kwargs))
 
     async def adelete(
-        self,
-        ids: Optional[List[str]] = None,
-        **kwargs: Any,
-    ) -> Optional[bool]:
+            self,
+            ids: list[str] | None = None,
+            **kwargs: Any,
+    ) -> bool | None:
         """Delete by document ID asynchronously.
 
         Args:
@@ -162,28 +166,28 @@ class SurrealDBStore(VectorStore):
             **kwargs: Other keyword arguments that subclasses might use.
 
         Returns:
-            Optional[bool]: True if deletion is successful,
+            bool | None: True if deletion is successful,
             False otherwise.
         """
 
         if ids is None:
-            await self.sdb.delete(self.collection)
+            self.sdb.delete(self.collection)
             return True
         else:
             if isinstance(ids, str):
-                await self.sdb.delete(ids)
+                self.sdb.delete(ids)
                 return True
             else:
                 if isinstance(ids, list) and len(ids) > 0:
-                    _ = [await self.sdb.delete(id) for id in ids]
+                    _ = [self.sdb.delete(id) for id in ids]
                     return True
         return False
 
     def delete(
-        self,
-        ids: Optional[List[str]] = None,
-        **kwargs: Any,
-    ) -> Optional[bool]:
+            self,
+            ids: list[str] | None = None,
+            **kwargs: Any,
+    ) -> bool | None:
         """Delete by document ID.
 
         Args:
@@ -191,31 +195,62 @@ class SurrealDBStore(VectorStore):
             **kwargs: Other keyword arguments that subclasses might use.
 
         Returns:
-            Optional[bool]: True if deletion is successful,
+            bool | None: True if deletion is successful,
             False otherwise.
         """
 
-        async def _delete(ids: Optional[List[str]], **kwargs: Any) -> Optional[bool]:
-            await self.initialize()
+        async def _delete(ids: list[str] | None, **kwargs: Any) -> bool | None:
+            self.initialize()
             return await self.adelete(ids=ids, **kwargs)
 
         return asyncio.run(_delete(ids, **kwargs))
 
+    def get_by_ids(self, ids: Sequence[str], /) -> list[Document]:
+        """Get documents by their IDs.
+
+        The returned documents are expected to have the ID field set to the ID of the
+        document in the vector store.
+
+        Fewer documents may be returned than requested if some IDs are not found or
+        if there are duplicated IDs.
+
+        Users should not assume that the order of the returned documents matches
+        the order of the input IDs. Instead, users should rely on the ID field of the
+        returned documents.
+
+        This method should **NOT** raise exceptions if no documents are found for
+        some IDs.
+
+        Args:
+            ids: List of ids to retrieve.
+
+        Returns:
+            List of Documents.
+        """
+        results = self.sdb.query(
+            "SELECT * FROM type::table($collection) WHERE id IN array::combine([$collection], $ids).map(|$v| type::thing($v[0], $v[1]))",
+            {"collection": self.collection, "ids": ids})
+        return [Document(
+            page_content=x.get("text"),
+            metadata=x.get("metadata", {}),
+            id=x.get("metadata").get("id"),
+        ) for x in results]
+
     async def _asimilarity_search_by_vector_with_score(
-        self,
-        embedding: List[float],
-        k: int = DEFAULT_K,
-        *,
-        filter: Optional[Dict[str, str]] = None,
-        **kwargs: Any,
-    ) -> List[Tuple[Document, float, Any]]:
+            self,
+            embedding: list[float],
+            k: int = DEFAULT_K,
+            *,
+            filter: dict[str, str] | None = None,
+            **kwargs: Any,
+    ) -> list[tuple[Document, float, Any]]:
         """Run similarity search for query embedding asynchronously
         and return documents and scores
 
         Args:
-            embedding (List[float]): Query embedding.
+            embedding (list[float]): Query embedding.
             k (int): Number of results to return. Defaults to 4.
-            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
+            filter (dict[str, str] | None): Filter by metadata. Defaults to None.
 
         Returns:
             List of Documents most similar along with scores
@@ -251,39 +286,31 @@ class SurrealDBStore(VectorStore):
           {custom_filter}
         order by similarity desc LIMIT $k;
         """
-        results = await self.sdb.query(query, args)
-
-        if len(results) == 0:
-            return []
-
-        result = results[0]
-
-        if result["status"] != "OK":
-            from surrealdb.ws import SurrealException
-
-            err = result.get("result", "Unknown Error")
-            raise SurrealException(err)
+        results = self.sdb.query(query, args)
 
         return [
             (
                 Document(
                     page_content=doc["text"],
-                    metadata={"id": doc["id"], **(doc.get("metadata") or {})},
+                    # metadata={"id": doc["id"], **(doc.get("metadata") or {})},
+                    metadata=doc.get("metadata", {}),
+                    # id=doc["id"].id
+                    id=doc.get("metadata").get("id"),
                 ),
                 doc["similarity"],
                 doc["embedding"],
             )
-            for doc in result["result"]
+            for doc in results
         ]
 
     async def asimilarity_search_with_relevance_scores(
-        self,
-        query: str,
-        k: int = DEFAULT_K,
-        *,
-        filter: Optional[Dict[str, str]] = None,
-        **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+            self,
+            query: str,
+            k: int = DEFAULT_K,
+            *,
+            filter: dict[str, str] | None = None,
+            **kwargs: Any,
+    ) -> list[tuple[Document, float]]:
         """Run similarity search asynchronously and return relevance scores
 
         Args:
@@ -305,13 +332,13 @@ class SurrealDBStore(VectorStore):
         ]
 
     def similarity_search_with_relevance_scores(
-        self,
-        query: str,
-        k: int = DEFAULT_K,
-        *,
-        filter: Optional[Dict[str, str]] = None,
-        **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+            self,
+            query: str,
+            k: int = DEFAULT_K,
+            *,
+            filter: dict[str, str] | None = None,
+            **kwargs: Any,
+    ) -> list[tuple[Document, float]]:
         """Run similarity search synchronously and return relevance scores
 
         Args:
@@ -323,10 +350,10 @@ class SurrealDBStore(VectorStore):
             List of Documents most similar along with relevance scores
         """
 
-        async def _similarity_search_with_relevance_scores() -> List[
-            Tuple[Document, float]
+        async def _similarity_search_with_relevance_scores() -> list[
+            tuple[Document, float]
         ]:
-            await self.initialize()
+            self.initialize()
             return await self.asimilarity_search_with_relevance_scores(
                 query, k, filter=filter, **kwargs
             )
@@ -334,13 +361,13 @@ class SurrealDBStore(VectorStore):
         return asyncio.run(_similarity_search_with_relevance_scores())
 
     async def asimilarity_search_with_score(
-        self,
-        query: str,
-        k: int = DEFAULT_K,
-        *,
-        filter: Optional[Dict[str, str]] = None,
-        **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+            self,
+            query: str,
+            k: int = DEFAULT_K,
+            *,
+            filter: dict[str, str] | None = None,
+            **kwargs: Any,
+    ) -> list[tuple[Document, float]]:
         """Run similarity search asynchronously and return distance scores
 
         Args:
@@ -362,13 +389,13 @@ class SurrealDBStore(VectorStore):
         ]
 
     def similarity_search_with_score(
-        self,
-        query: str,
-        k: int = DEFAULT_K,
-        *,
-        filter: Optional[Dict[str, str]] = None,
-        **kwargs: Any,
-    ) -> List[Tuple[Document, float]]:
+            self,
+            query: str,
+            k: int = DEFAULT_K,
+            *,
+            filter: dict[str, str] | None = None,
+            **kwargs: Any,
+    ) -> list[tuple[Document, float]]:
         """Run similarity search synchronously and return distance scores
 
         Args:
@@ -380,8 +407,8 @@ class SurrealDBStore(VectorStore):
             List of Documents most similar along with relevance distance scores
         """
 
-        async def _similarity_search_with_score() -> List[Tuple[Document, float]]:
-            await self.initialize()
+        async def _similarity_search_with_score() -> list[tuple[Document, float]]:
+            self.initialize()
             return await self.asimilarity_search_with_score(
                 query, k, filter=filter, **kwargs
             )
@@ -389,17 +416,17 @@ class SurrealDBStore(VectorStore):
         return asyncio.run(_similarity_search_with_score())
 
     async def asimilarity_search_by_vector(
-        self,
-        embedding: List[float],
-        k: int = DEFAULT_K,
-        *,
-        filter: Optional[Dict[str, str]] = None,
-        **kwargs: Any,
-    ) -> List[Document]:
+            self,
+            embedding: list[float],
+            k: int = DEFAULT_K,
+            *,
+            filter: dict[str, str] | None = None,
+            **kwargs: Any,
+    ) -> list[Document]:
         """Run similarity search on query embedding asynchronously
 
         Args:
-            embedding (List[float]): Query embedding
+            embedding (list[float]): Query embedding
             k (int): Number of results to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
 
@@ -414,17 +441,17 @@ class SurrealDBStore(VectorStore):
         ]
 
     def similarity_search_by_vector(
-        self,
-        embedding: List[float],
-        k: int = DEFAULT_K,
-        *,
-        filter: Optional[Dict[str, str]] = None,
-        **kwargs: Any,
-    ) -> List[Document]:
+            self,
+            embedding: list[float],
+            k: int = DEFAULT_K,
+            *,
+            filter: dict[str, str] | None = None,
+            **kwargs: Any,
+    ) -> list[Document]:
         """Run similarity search on query embedding
 
         Args:
-            embedding (List[float]): Query embedding
+            embedding (list[float]): Query embedding
             k (int): Number of results to return. Defaults to 4.
             filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
 
@@ -432,8 +459,8 @@ class SurrealDBStore(VectorStore):
             List of Documents most similar to the query
         """
 
-        async def _similarity_search_by_vector() -> List[Document]:
-            await self.initialize()
+        async def _similarity_search_by_vector() -> list[Document]:
+            self.initialize()
             return await self.asimilarity_search_by_vector(
                 embedding, k, filter=filter, **kwargs
             )
@@ -441,13 +468,13 @@ class SurrealDBStore(VectorStore):
         return asyncio.run(_similarity_search_by_vector())
 
     async def asimilarity_search(
-        self,
-        query: str,
-        k: int = DEFAULT_K,
-        *,
-        filter: Optional[Dict[str, str]] = None,
-        **kwargs: Any,
-    ) -> List[Document]:
+            self,
+            query: str,
+            k: int = DEFAULT_K,
+            *,
+            filter: dict[str, str] | None = None,
+            **kwargs: Any,
+    ) -> list[Document]:
         """Run similarity search on query asynchronously
 
         Args:
@@ -464,13 +491,13 @@ class SurrealDBStore(VectorStore):
         )
 
     def similarity_search(
-        self,
-        query: str,
-        k: int = DEFAULT_K,
-        *,
-        filter: Optional[Dict[str, str]] = None,
-        **kwargs: Any,
-    ) -> List[Document]:
+            self,
+            query: str,
+            k: int = DEFAULT_K,
+            *,
+            filter: dict[str, str] | None = None,
+            **kwargs: Any,
+    ) -> list[Document]:
         """Run similarity search on query
 
         Args:
@@ -482,22 +509,22 @@ class SurrealDBStore(VectorStore):
             List of Documents most similar to the query
         """
 
-        async def _similarity_search() -> List[Document]:
-            await self.initialize()
+        async def _similarity_search() -> list[Document]:
+            self.initialize()
             return await self.asimilarity_search(query, k, filter=filter, **kwargs)
 
         return asyncio.run(_similarity_search())
 
     async def amax_marginal_relevance_search_by_vector(
-        self,
-        embedding: List[float],
-        k: int = DEFAULT_K,
-        fetch_k: int = 20,
-        lambda_mult: float = 0.5,
-        *,
-        filter: Optional[Dict[str, str]] = None,
-        **kwargs: Any,
-    ) -> List[Document]:
+            self,
+            embedding: list[float],
+            k: int = DEFAULT_K,
+            fetch_k: int = 20,
+            lambda_mult: float = 0.5,
+            *,
+            filter: dict[str, str] | None = None,
+            **kwargs: Any,
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance.
         Maximal marginal relevance optimizes for similarity to query AND diversity
         among selected documents.
@@ -535,15 +562,15 @@ class SurrealDBStore(VectorStore):
         return [docs[i] for i in mmr_selected]
 
     def max_marginal_relevance_search_by_vector(
-        self,
-        embedding: List[float],
-        k: int = DEFAULT_K,
-        fetch_k: int = 20,
-        lambda_mult: float = 0.5,
-        *,
-        filter: Optional[Dict[str, str]] = None,
-        **kwargs: Any,
-    ) -> List[Document]:
+            self,
+            embedding: list[float],
+            k: int = DEFAULT_K,
+            fetch_k: int = 20,
+            lambda_mult: float = 0.5,
+            *,
+            filter: dict[str, str] | None = None,
+            **kwargs: Any,
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance.
 
         Maximal marginal relevance optimizes for similarity to query AND diversity
@@ -563,8 +590,8 @@ class SurrealDBStore(VectorStore):
             List of Documents selected by maximal marginal relevance.
         """
 
-        async def _max_marginal_relevance_search_by_vector() -> List[Document]:
-            await self.initialize()
+        async def _max_marginal_relevance_search_by_vector() -> list[Document]:
+            self.initialize()
             return await self.amax_marginal_relevance_search_by_vector(
                 embedding, k, fetch_k, lambda_mult, filter=filter, **kwargs
             )
@@ -572,15 +599,15 @@ class SurrealDBStore(VectorStore):
         return asyncio.run(_max_marginal_relevance_search_by_vector())
 
     async def amax_marginal_relevance_search(
-        self,
-        query: str,
-        k: int = 4,
-        fetch_k: int = 20,
-        lambda_mult: float = 0.5,
-        *,
-        filter: Optional[Dict[str, str]] = None,
-        **kwargs: Any,
-    ) -> List[Document]:
+            self,
+            query: str,
+            k: int = 4,
+            fetch_k: int = 20,
+            lambda_mult: float = 0.5,
+            *,
+            filter: dict[str, str] | None = None,
+            **kwargs: Any,
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance.
 
         Maximal marginal relevance optimizes for similarity to query AND diversity
@@ -607,15 +634,15 @@ class SurrealDBStore(VectorStore):
         return docs
 
     def max_marginal_relevance_search(
-        self,
-        query: str,
-        k: int = DEFAULT_K,
-        fetch_k: int = 20,
-        lambda_mult: float = 0.5,
-        *,
-        filter: Optional[Dict[str, str]] = None,
-        **kwargs: Any,
-    ) -> List[Document]:
+            self,
+            query: str,
+            k: int = DEFAULT_K,
+            fetch_k: int = 20,
+            lambda_mult: float = 0.5,
+            *,
+            filter: dict[str, str] | None = None,
+            **kwargs: Any,
+    ) -> list[Document]:
         """Return docs selected using the maximal marginal relevance.
         Maximal marginal relevance optimizes for similarity to query AND diversity
         among selected documents.
@@ -634,8 +661,8 @@ class SurrealDBStore(VectorStore):
             List of Documents selected by maximal marginal relevance.
         """
 
-        async def _max_marginal_relevance_search() -> List[Document]:
-            await self.initialize()
+        async def _max_marginal_relevance_search() -> list[Document]:
+            self.initialize()
             return await self.amax_marginal_relevance_search(
                 query, k, fetch_k, lambda_mult, filter=filter, **kwargs
             )
@@ -644,16 +671,16 @@ class SurrealDBStore(VectorStore):
 
     @classmethod
     async def afrom_texts(
-        cls,
-        texts: List[str],
-        embedding: Embeddings,
-        metadatas: Optional[List[dict]] = None,
-        **kwargs: Any,
+            cls,
+            texts: list[str],
+            embedding: Embeddings,
+            metadatas: list[dict] | None = None,
+            **kwargs: Any,
     ) -> "SurrealDBStore":
         """Create SurrealDBStore from list of text asynchronously
 
         Args:
-            texts (List[str]): list of text to vectorize and store
+            texts (list[str]): list of text to vectorize and store
             embedding (Optional[Embeddings]): Embedding function.
             dburl (str): SurrealDB connection url
                 (default: "ws://localhost:8000/rpc")
@@ -670,22 +697,22 @@ class SurrealDBStore(VectorStore):
             SurrealDBStore object initialized and ready for use."""
 
         sdb = cls(embedding, **kwargs)
-        await sdb.initialize()
+        sdb.initialize()
         await sdb.aadd_texts(texts, metadatas, **kwargs)
         return sdb
 
     @classmethod
     def from_texts(
-        cls,
-        texts: List[str],
-        embedding: Embeddings,
-        metadatas: Optional[List[dict]] = None,
-        **kwargs: Any,
+            cls,
+            texts: list[str],
+            embedding: Embeddings,
+            metadatas: list[dict] | None = None,
+            **kwargs: Any,
     ) -> "SurrealDBStore":
         """Create SurrealDBStore from list of text
 
         Args:
-            texts (List[str]): list of text to vectorize and store
+            texts (list[str]): list of text to vectorize and store
             embedding (Optional[Embeddings]): Embedding function.
             dburl (str): SurrealDB connection url
             ns (str): surrealdb namespace for the vector store.

--- a/libs/community/langchain_community/vectorstores/surrealdb.py
+++ b/libs/community/langchain_community/vectorstores/surrealdb.py
@@ -77,6 +77,15 @@ class SurrealDBStore(VectorStore):
         self.embedding_function = embedding_function
         self.kwargs = kwargs
 
+    def _create_indexes(self, dim: int) -> None:
+        # TODO: check if it already exists
+        self.sdb.query(f"""
+        DEFINE INDEX embedding_vector_index
+            ON {self.collection}
+            FIELDS embedding
+            MTREE DIMENSION {dim} DIST COSINE TYPE F32;
+        """)
+
     def initialize(self) -> None:
         """
         Initialize connection to surrealdb database
@@ -88,6 +97,8 @@ class SurrealDBStore(VectorStore):
             password = self.kwargs.get("db_pass")
             self.sdb.signin({"username": user, "password": password})
         self.sdb.use(self.ns, self.db)
+        # TODO: parametrise vector dimension
+        self._create_indexes(6)
 
     @property
     def embeddings(self) -> Embeddings | None:
@@ -175,11 +186,11 @@ class SurrealDBStore(VectorStore):
             return True
         else:
             if isinstance(ids, str):
-                self.sdb.delete(ids)
+                self.sdb.delete(RecordID(self.collection, ids))
                 return True
             else:
                 if isinstance(ids, list) and len(ids) > 0:
-                    _ = [self.sdb.delete(id) for id in ids]
+                    _ = [self.sdb.delete(RecordID(self.collection,id)) for id in ids]
                     return True
         return False
 
@@ -227,14 +238,17 @@ class SurrealDBStore(VectorStore):
         Returns:
             List of Documents.
         """
-        results = self.sdb.query(
+        query_results = self.sdb.query(
             "SELECT * FROM type::table($collection) WHERE id IN array::combine([$collection], $ids).map(|$v| type::thing($v[0], $v[1]))",
             {"collection": self.collection, "ids": ids})
-        return [Document(
+        docs = {x.get("id").id: Document(
             page_content=x.get("text"),
             metadata=x.get("metadata", {}),
-            id=x.get("metadata").get("id"),
-        ) for x in results]
+            id=x.get("id").id,
+        ) for x in query_results}
+        # sort docs in the same order as the passed in IDs
+        return [docs.get(key) for key in ids if docs.get(key) is not None]
+
 
     async def _asimilarity_search_by_vector_with_score(
             self,
@@ -259,7 +273,7 @@ class SurrealDBStore(VectorStore):
             "collection": self.collection,
             "embedding": embedding,
             "k": k,
-            "score_threshold": kwargs.get("score_threshold", 0),
+            "score_threshold": kwargs.get("score_threshold", -1),
         }
 
         # build additional filter criteria
@@ -275,16 +289,25 @@ class SurrealDBStore(VectorStore):
                 custom_filter += f"and metadata.{key} = {filter_value} "
 
         query = f"""
-        select
-            id,
-            text,
-            metadata,
-            embedding,
-            vector::similarity::cosine(embedding, $embedding) as similarity
-        from ⟨{args["collection"]}⟩
-        where vector::similarity::cosine(embedding, $embedding) >= $score_threshold
-          {custom_filter}
-        order by similarity desc LIMIT $k;
+            SELECT
+                id,
+                text,
+                metadata,
+                embedding,
+                similarity
+            FROM (
+                SELECT
+                    id,
+                    text,
+                    metadata,
+                    embedding,
+                    vector::similarity::cosine(embedding, $embedding) as similarity
+                FROM type::table($collection)
+                WHERE embedding <|{k}|> $embedding
+                    {custom_filter}
+            )
+            WHERE similarity >= $score_threshold
+            ORDER BY similarity DESC
         """
         results = self.sdb.query(query, args)
 
@@ -294,7 +317,6 @@ class SurrealDBStore(VectorStore):
                     page_content=doc["text"],
                     # metadata={"id": doc["id"], **(doc.get("metadata") or {})},
                     metadata=doc.get("metadata", {}),
-                    # id=doc["id"].id
                     id=doc.get("metadata").get("id"),
                 ),
                 doc["similarity"],

--- a/libs/community/langchain_community/vectorstores/surrealdb.py
+++ b/libs/community/langchain_community/vectorstores/surrealdb.py
@@ -124,22 +124,20 @@ class SurrealDBStore(VectorStore):
         self._ensure_index()
 
     def _ensure_index(self) -> None:
+        query = f"""
+            DEFINE INDEX IF NOT EXISTS {self.index_name}
+                ON TABLE {self.table}
+                FIELDS embedding
+                MTREE DIMENSION {self.embedding_dimension} DIST COSINE TYPE F32
+                CONCURRENTLY;
+        """
         if self.async_connection is not None:
-            self.async_connection.query(f"""
-                DEFINE INDEX IF NOT EXISTS {self.index_name}
-                    ON TABLE {self.table}
-                    FIELDS embedding
-                    MTREE DIMENSION {self.embedding_dimension} DIST COSINE TYPE F32
-                    CONCURRENTLY;
-            """)
+            loop = asyncio.get_event_loop()
+            loop.create_task(
+                self.async_connection.query(query)
+            )
         elif self.connection is not None:
-            self.connection.query(f"""
-                DEFINE INDEX IF NOT EXISTS {self.index_name}
-                    ON TABLE {self.table}
-                    FIELDS embedding
-                    MTREE DIMENSION {self.embedding_dimension} DIST COSINE TYPE F32
-                    CONCURRENTLY;
-            """)
+            self.connection.query(query)
         else:
             raise ValueError("No connection provided")
 
@@ -262,9 +260,29 @@ class SurrealDBStore(VectorStore):
 
         return [docs[i] for i in mmr_selected]
 
+    def _aux(
+            self,
+            embedding: list[float],
+            *,
+            k: int = DEFAULT_K,
+            score_threshold: float = -1,
+            custom_filter: dict[str, str] | None = None,
+    ) -> list[tuple[Document, float, list[float]]]:
+        if self.connection is None:
+            raise ValueError("No connection provided")
+        query, args = self._build_search_query(
+            embedding, k, score_threshold, custom_filter
+        )
+        results = self.connection.query(query, args)
+        return self._parse_results(results)
+
     # =========================================================================
     # == Extended methods
     # =========================================================================
+
+    @property
+    def embeddings(self) -> Embeddings | None:
+        return self.embedding if isinstance(self.embedding, Embeddings) else None
 
     def add_texts(
         self,
@@ -296,9 +314,38 @@ class SurrealDBStore(VectorStore):
                 result_ids.append(inserted["id"].id)
         return result_ids
 
-    @property
-    def embeddings(self) -> Embeddings | None:
-        return self.embedding if isinstance(self.embedding, Embeddings) else None
+    async def aadd_texts(
+            self,
+            texts: Iterable[str],
+            metadatas: list[dict] | None = None,
+            *,
+            ids: list[str] | None = None,
+            **kwargs: Any,
+    ) -> list[str]:
+        if self.async_connection is None:
+            raise ValueError("No async connection provided")
+        embeddings = self.embedding.embed_documents(list(texts))
+        result_ids = []
+        coroutines = []
+        for idx, text in enumerate(texts):
+            record_id, data = self._build_text_data(
+                text,
+                embeddings[idx],
+                metadatas[idx] if metadatas is not None else None,
+                ids[idx] if ids is not None else None,
+            )
+            if record_id is not None:
+                coroutines.append(self.async_connection.upsert(record_id, data))
+            else:
+                coroutines.append(self.async_connection.insert(self.table, data))
+        results = await asyncio.gather(*coroutines)
+        for inserted in results:
+            if isinstance(inserted, list):
+                for record in inserted:
+                    result_ids.append(record["id"].id)
+            elif isinstance(inserted, dict):
+                result_ids.append(inserted["id"].id)
+        return result_ids
 
     def delete(
         self,
@@ -313,6 +360,23 @@ class SurrealDBStore(VectorStore):
                     self.connection.delete(RecordID(self.table, id))
             else:
                 self.connection.delete(self.table)
+        except Exception as _e:
+            return False
+        return True
+
+    async def adelete(
+            self, ids: Optional[list[str]] = None, **kwargs: Any
+    ) -> Optional[bool]:
+        if self.async_connection is None:
+            raise ValueError("No async connection provided")
+        try:
+            if ids is not None:
+                coroutines = [
+                    self.async_connection.delete(RecordID(self.table, id)) for id in ids
+                ]
+                await asyncio.gather(*coroutines)
+            else:
+                await self.async_connection.delete(self.table)
         except Exception as _e:
             return False
         return True
@@ -335,50 +399,6 @@ class SurrealDBStore(VectorStore):
         )
         return self._parse_documents(ids, query_results)
 
-    async def adelete(
-        self, ids: Optional[list[str]] = None, **kwargs: Any
-    ) -> Optional[bool]:
-        if self.async_connection is None:
-            raise ValueError("No async connection provided")
-        try:
-            if ids is not None:
-                coroutines = [
-                    self.async_connection.delete(RecordID(self.table, id)) for id in ids
-                ]
-                await asyncio.gather(*coroutines)
-            else:
-                await self.async_connection.delete(self.table)
-        except Exception as _e:
-            return False
-        return True
-
-    async def aadd_texts(
-        self,
-        texts: Iterable[str],
-        metadatas: list[dict] | None = None,
-        *,
-        ids: list[str] | None = None,
-        **kwargs: Any,
-    ) -> list[str]:
-        if self.async_connection is None:
-            raise ValueError("No async connection provided")
-        embeddings = self.embedding.embed_documents(list(texts))
-        coroutines = []
-        for idx, text in enumerate(texts):
-            record_id, data = self._build_text_data(
-                text,
-                embeddings[idx],
-                metadatas[idx] if metadatas is not None else None,
-                ids[idx] if ids is not None else None,
-            )
-            if record_id is not None:
-                coroutines.append(self.async_connection.upsert(record_id, data))
-            else:
-                coroutines.append(self.async_connection.insert(self.table, data))
-        results = await asyncio.gather(*coroutines)
-        result_ids = [x.get("id") for x in results]
-        return result_ids
-
     def similarity_search(
         self,
         query: str,
@@ -392,26 +412,6 @@ class SurrealDBStore(VectorStore):
             query_embedding, k, custom_filter=custom_filter, **kwargs
         )
 
-    # TODO: implement
-    def _select_relevance_score_fn(self) -> Callable[[float], float]:
-        raise NotImplementedError
-
-    def aux(
-        self,
-        embedding: list[float],
-        *,
-        k: int = DEFAULT_K,
-        score_threshold: float = -1,
-        custom_filter: dict[str, str] | None = None,
-    ) -> list[tuple[Document, float, list[float]]]:
-        if self.connection is None:
-            raise ValueError("No connection provided")
-        query, args = self._build_search_query(
-            embedding, k, score_threshold, custom_filter
-        )
-        results = self.connection.query(query, args)
-        return self._parse_results(results)
-
     def similarity_search_with_score(
         self,
         query: str,
@@ -423,7 +423,7 @@ class SurrealDBStore(VectorStore):
         embedding = self.embedding.embed_query(query)
         return [
             (d, s)
-            for d, s, _ in self.aux(
+            for d, s, _ in self._aux(
                 embedding,
                 k=k,
                 score_threshold=score_threshold,
@@ -441,7 +441,7 @@ class SurrealDBStore(VectorStore):
     ) -> list[Document]:
         return [
             document
-            for document, _, _ in self.aux(
+            for document, _, _ in self._aux(
                 embedding=embedding, k=k, custom_filter=custom_filter
             )
         ]
@@ -506,6 +506,10 @@ class SurrealDBStore(VectorStore):
         store = SurrealDBStore(embedding, None, async_connection=connection)
         await store.aadd_texts(texts, metadatas)
         return store
+
+    # TODO: implement
+    def _select_relevance_score_fn(self) -> Callable[[float], float]:
+        raise NotImplementedError
 
     # =========================================================================
     # =========================================================================

--- a/libs/community/langchain_community/vectorstores/surrealdb.py
+++ b/libs/community/langchain_community/vectorstores/surrealdb.py
@@ -1,15 +1,49 @@
+from __future__ import annotations
+
 import asyncio
-from typing import Iterable, Any, Sequence
+from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, Sequence, Union
 
 import numpy as np
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.vectorstores import VectorStore
-from surrealdb import RecordID
+from surrealdb import (
+    AsyncHttpSurrealConnection,
+    AsyncWsSurrealConnection,
+    BlockingHttpSurrealConnection,
+    BlockingWsSurrealConnection,
+    RecordID,
+)
 
 from langchain_community.vectorstores.utils import maximal_marginal_relevance
 
+if TYPE_CHECKING:
+    from surrealdb import AsyncSurreal, Surreal
+
 DEFAULT_K = 4  # Number of Documents to return.
+
+type SurrealConnection = Union[
+    BlockingWsSurrealConnection, BlockingHttpSurrealConnection
+]
+type SurrealAsyncConnection = Union[
+    AsyncWsSurrealConnection, AsyncHttpSurrealConnection
+]
+
+GET_BY_ID_QUERY = """
+    SELECT *
+    FROM type::table($table)
+    WHERE id IN array::combine([$table], $ids)
+        .map(|$v| type::thing($v[0], $v[1]))
+"""
+
+# # Development commands:
+#
+# ```sh
+# surreal start -u root -p root -l debug
+# make integration_tests TEST_FILE=tests/integration_tests/vectorstores/test_surrealdb.py. # noqa: E501
+# make format
+# make lint
+# ```
 
 
 class SurrealDBStore(VectorStore):
@@ -19,14 +53,9 @@ class SurrealDBStore(VectorStore):
     To use, you should have the ``surrealdb`` python package installed.
 
     Args:
-        embedding_function: Embedding function to use.
-        dburl: SurrealDB connection url
-        ns: surrealdb namespace for the vector store. (default: "langchain")
-        db: surrealdb database for the vector store. (default: "database")
-        collection: surrealdb collection for the vector store.
-            (default: "documents")
-
-        (optional) db_user and db_pass: surrealdb credentials
+        embedding: The embedding function or model to use for generating embeddings.
+        table: SurrealDB table for the vector store (default: "documents").
+        connection: SurrealDB connection
 
     Example:
         .. code-block:: python
@@ -35,258 +64,115 @@ class SurrealDBStore(VectorStore):
             from langchain_community.embeddings import HuggingFaceEmbeddings
 
             model_name = "sentence-transformers/all-mpnet-base-v2"
-            embedding_function = HuggingFaceEmbeddings(model_name=model_name)
-            dburl = "ws://localhost:8000/rpc"
-            ns = "langchain"
-            db = "docstore"
-            collection = "documents"
-            db_user = "root"
-            db_pass = "root"
+            embedding = HuggingFaceEmbeddings(model_name=model_name)
 
-            sdb = SurrealDBStore.from_texts(
-                    texts=texts,
-                    embedding=embedding_function,
-                    dburl,
-                    ns, db, collection,
-                    db_user=db_user, db_pass=db_pass)
+            conn = Surreal("ws://localhost:8000/rpc")
+            conn.signin({"username": "root", "password": "root"})
+            conn.use("langchain", "test")
+
+            connection = SurrealDBStore.from_texts(
+                texts=texts,
+                embedding=embedding,
+                connection=conn
+            )
     """
 
     def __init__(
-            self,
-            embedding_function: Embeddings,
-            **kwargs: Any,
+        self,
+        embedding: Embeddings,
+        connection: SurrealConnection | None,
+        table: str = "documents",
+        index_name: str = "documents_vector_index",
+        embedding_dimension: int | None = None,
+        async_connection: SurrealAsyncConnection | None = None,
     ) -> None:
-        try:
-            from surrealdb import Surreal
-        except ImportError as e:
-            raise ImportError(
-                """Cannot import from surrealdb.
-                please install with `pip install surrealdb`."""
-            ) from e
-
-        self.dburl = kwargs.pop("dburl", "ws://localhost:8000/rpc")
-
-        if self.dburl[0:2] == "ws":
-            self.sdb = Surreal(self.dburl)
+        self.embedding = embedding
+        self.table = table
+        self.index_name = index_name
+        self.connection = connection
+        self.async_connection = async_connection
+        if embedding_dimension is not None:
+            self.embedding_dimension = embedding_dimension
         else:
-            raise ValueError("Only websocket connections are supported at this time.")
+            self.embedding_dimension = len(self.embedding.embed_query("foo"))
+        self._ensure_index()
 
-        self.ns = kwargs.pop("ns", "langchain")
-        self.db = kwargs.pop("db", "database")
-        self.collection = kwargs.pop("collection", "documents")
-        self.embedding_function = embedding_function
-        self.kwargs = kwargs
+    def _ensure_index(self) -> None:
+        if self.async_connection is not None:
+            self.async_connection.query(f"""
+                DEFINE INDEX IF NOT EXISTS {self.index_name}
+                    ON TABLE {self.table}
+                    FIELDS embedding
+                    MTREE DIMENSION {self.embedding_dimension} DIST COSINE TYPE F32
+                    CONCURRENTLY;
+            """)
+        elif self.connection is not None:
+            self.connection.query(f"""
+                DEFINE INDEX IF NOT EXISTS {self.index_name}
+                    ON TABLE {self.table}
+                    FIELDS embedding
+                    MTREE DIMENSION {self.embedding_dimension} DIST COSINE TYPE F32
+                    CONCURRENTLY;
+            """)
+        else:
+            raise ValueError("No connection provided")
 
-    def _create_indexes(self, dim: int) -> None:
-        # TODO: check if it already exists
-        self.sdb.query(f"""
-        DEFINE INDEX embedding_vector_index
-            ON {self.collection}
-            FIELDS embedding
-            MTREE DIMENSION {dim} DIST COSINE TYPE F32;
-        """)
-
-    def initialize(self) -> None:
-        """
-        Initialize connection to surrealdb database
-        and authenticate if credentials are provided
-        """
-        # await self.sdb.connect()
-        if "db_user" in self.kwargs and "db_pass" in self.kwargs:
-            user = self.kwargs.get("db_user")
-            password = self.kwargs.get("db_pass")
-            self.sdb.signin({"username": user, "password": password})
-        self.sdb.use(self.ns, self.db)
-        # TODO: parametrise vector dimension
-        self._create_indexes(6)
-
-    @property
-    def embeddings(self) -> Embeddings | None:
-        return (
-            self.embedding_function
-            if isinstance(self.embedding_function, Embeddings)
-            else None
+    def _build_text_data(
+        self, text: str, embedding: list[float], metadata: dict | None, id: str | None
+    ) -> tuple[str, dict]:
+        preferred_id = None
+        data = {"text": text, "embedding": embedding, "metadata": {}}
+        if metadata is not None:
+            data["metadata"] = metadata
+            preferred_id = metadata.get("id")
+        if id is not None:
+            preferred_id = id
+        record_id = (
+            RecordID(self.table, preferred_id)
+            if preferred_id is not None
+            else self.table
         )
+        return record_id, data
 
-    async def aadd_texts(
-            self,
-            texts: Iterable[str],
-            metadatas: list[dict] | None = None,
-            **kwargs: Any,
-    ) -> list[str]:
-        """Add list of text along with embeddings to the vector store asynchronously
-
-        Args:
-            texts (Iterable[str]): collection of text to add to the database
-
-        Returns:
-            List of ids for the newly inserted documents
-        """
-        embeddings = self.embedding_function.embed_documents(list(texts))
-        ids = []
-        for idx, text in enumerate(texts):
-            data = {"text": text, "embedding": embeddings[idx], "metadata": {}}
-            if metadatas is not None and idx < len(metadatas):
-                data["metadata"] = metadatas[idx]  # type: ignore[assignment]
-            preferred_id = data["metadata"].get("id")
-            kwargs_ids = kwargs.get("ids", [])
-            if kwargs_ids and idx < len(kwargs_ids) and kwargs_ids[idx] is not None:
-                preferred_id = kwargs_ids[idx]
-
-            # TODO: consider using insert and make a single bulk insert call, but not if we have IDs in the metadata or
-            #       in kwargs, because only with `create` we can specify IDs
-            record_id = RecordID(self.collection, preferred_id) if preferred_id is not None else self.collection
-            record = self.sdb.upsert(record_id, data)
-            ids.append(record.get("id").id)
-        return ids
-
-    def add_texts(
-            self,
-            texts: Iterable[str],
-            metadatas: list[dict] | None = None,
-            **kwargs: Any,
-    ) -> list[str]:
-        """Add list of text along with embeddings to the vector store
-
-        Args:
-            texts (Iterable[str]): collection of text to add to the database
-
-        Returns:
-            List of ids for the newly inserted documents
-        """
-
-        async def _add_texts(
-                texts: Iterable[str],
-                metadatas: list[dict] | None = None,
-                **kwargs: Any,
-        ) -> list[str]:
-            self.initialize()
-            return await self.aadd_texts(texts, metadatas, **kwargs)
-
-        return asyncio.run(_add_texts(texts, metadatas, **kwargs))
-
-    async def adelete(
-            self,
-            ids: list[str] | None = None,
-            **kwargs: Any,
-    ) -> bool | None:
-        """Delete by document ID asynchronously.
-
-        Args:
-            ids: List of ids to delete.
-            **kwargs: Other keyword arguments that subclasses might use.
-
-        Returns:
-            bool | None: True if deletion is successful,
-            False otherwise.
-        """
-
-        if ids is None:
-            self.sdb.delete(self.collection)
-            return True
-        else:
-            if isinstance(ids, str):
-                self.sdb.delete(RecordID(self.collection, ids))
-                return True
-            else:
-                if isinstance(ids, list) and len(ids) > 0:
-                    _ = [self.sdb.delete(RecordID(self.collection,id)) for id in ids]
-                    return True
-        return False
-
-    def delete(
-            self,
-            ids: list[str] | None = None,
-            **kwargs: Any,
-    ) -> bool | None:
-        """Delete by document ID.
-
-        Args:
-            ids: List of ids to delete.
-            **kwargs: Other keyword arguments that subclasses might use.
-
-        Returns:
-            bool | None: True if deletion is successful,
-            False otherwise.
-        """
-
-        async def _delete(ids: list[str] | None, **kwargs: Any) -> bool | None:
-            self.initialize()
-            return await self.adelete(ids=ids, **kwargs)
-
-        return asyncio.run(_delete(ids, **kwargs))
-
-    def get_by_ids(self, ids: Sequence[str], /) -> list[Document]:
-        """Get documents by their IDs.
-
-        The returned documents are expected to have the ID field set to the ID of the
-        document in the vector store.
-
-        Fewer documents may be returned than requested if some IDs are not found or
-        if there are duplicated IDs.
-
-        Users should not assume that the order of the returned documents matches
-        the order of the input IDs. Instead, users should rely on the ID field of the
-        returned documents.
-
-        This method should **NOT** raise exceptions if no documents are found for
-        some IDs.
-
-        Args:
-            ids: List of ids to retrieve.
-
-        Returns:
-            List of Documents.
-        """
-        query_results = self.sdb.query(
-            "SELECT * FROM type::table($collection) WHERE id IN array::combine([$collection], $ids).map(|$v| type::thing($v[0], $v[1]))",
-            {"collection": self.collection, "ids": ids})
-        docs = {x.get("id").id: Document(
-            page_content=x.get("text"),
-            metadata=x.get("metadata", {}),
-            id=x.get("id").id,
-        ) for x in query_results}
+    def _parse_documents(
+        self, ids: Sequence[str], results: list[dict]
+    ) -> list[Document]:
+        docs = {
+            x.get("id").id: Document(
+                page_content=x.get("text"),
+                metadata=x.get("metadata", {}),
+                id=x.get("id").id,
+            )
+            for x in results
+        }
         # sort docs in the same order as the passed in IDs
         return [docs.get(key) for key in ids if docs.get(key) is not None]
 
-
-    async def _asimilarity_search_by_vector_with_score(
-            self,
-            embedding: list[float],
-            k: int = DEFAULT_K,
-            *,
-            filter: dict[str, str] | None = None,
-            **kwargs: Any,
-    ) -> list[tuple[Document, float, Any]]:
-        """Run similarity search for query embedding asynchronously
-        and return documents and scores
-
-        Args:
-            embedding (list[float]): Query embedding.
-            k (int): Number of results to return. Defaults to 4.
-            filter (dict[str, str] | None): Filter by metadata. Defaults to None.
-
-        Returns:
-            List of Documents most similar along with scores
-        """
+    def _build_search_query(
+        self,
+        embedding: list[float],
+        k: int,
+        score_threshold: float,
+        custom_filter: dict,
+    ) -> tuple[str, dict]:
         args = {
-            "collection": self.collection,
+            "table": self.table,
             "embedding": embedding,
             "k": k,
-            "score_threshold": kwargs.get("score_threshold", -1),
+            "score_threshold": score_threshold,
         }
 
         # build additional filter criteria
-        custom_filter = ""
-        if filter:
-            for key in filter:
+        custom_filter_str = ""
+        if custom_filter:
+            for key in custom_filter:
                 # check value type
-                if type(filter[key]) in [str, bool]:
-                    filter_value = f"'{filter[key]}'"
+                if type(custom_filter[key]) in [str, bool]:
+                    filter_value = f"'{custom_filter[key]}'"
                 else:
-                    filter_value = f"{filter[key]}"
+                    filter_value = f"{custom_filter[key]}"
 
-                custom_filter += f"and metadata.{key} = {filter_value} "
+                custom_filter_str += f"and metadata.{key} = {filter_value} "
 
         query = f"""
             SELECT
@@ -302,20 +188,23 @@ class SurrealDBStore(VectorStore):
                     metadata,
                     embedding,
                     vector::similarity::cosine(embedding, $embedding) as similarity
-                FROM type::table($collection)
+                FROM type::table($table)
                 WHERE embedding <|{k}|> $embedding
-                    {custom_filter}
+                    {custom_filter_str}
             )
             WHERE similarity >= $score_threshold
             ORDER BY similarity DESC
         """
-        results = self.sdb.query(query, args)
 
+        return query, args
+
+    def _parse_results(
+        self, results: list[dict]
+    ) -> list[tuple[Document, float, list[float]]]:
         return [
             (
                 Document(
                     page_content=doc["text"],
-                    # metadata={"id": doc["id"], **(doc.get("metadata") or {})},
                     metadata=doc.get("metadata", {}),
                     id=doc.get("metadata").get("id"),
                 ),
@@ -325,254 +214,17 @@ class SurrealDBStore(VectorStore):
             for doc in results
         ]
 
-    async def asimilarity_search_with_relevance_scores(
-            self,
-            query: str,
-            k: int = DEFAULT_K,
-            *,
-            filter: dict[str, str] | None = None,
-            **kwargs: Any,
-    ) -> list[tuple[Document, float]]:
-        """Run similarity search asynchronously and return relevance scores
-
-        Args:
-            query (str): Query
-            k (int): Number of results to return. Defaults to 4.
-            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-
-        Returns:
-            List of Documents most similar along with relevance scores
-        """
-        query_embedding = self.embedding_function.embed_query(query)
-        return [
-            (document, similarity)
-            for document, similarity, _ in (
-                await self._asimilarity_search_by_vector_with_score(
-                    query_embedding, k, filter=filter, **kwargs
-                )
-            )
-        ]
-
-    def similarity_search_with_relevance_scores(
-            self,
-            query: str,
-            k: int = DEFAULT_K,
-            *,
-            filter: dict[str, str] | None = None,
-            **kwargs: Any,
-    ) -> list[tuple[Document, float]]:
-        """Run similarity search synchronously and return relevance scores
-
-        Args:
-            query (str): Query
-            k (int): Number of results to return. Defaults to 4.
-            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-
-        Returns:
-            List of Documents most similar along with relevance scores
-        """
-
-        async def _similarity_search_with_relevance_scores() -> list[
-            tuple[Document, float]
-        ]:
-            self.initialize()
-            return await self.asimilarity_search_with_relevance_scores(
-                query, k, filter=filter, **kwargs
-            )
-
-        return asyncio.run(_similarity_search_with_relevance_scores())
-
-    async def asimilarity_search_with_score(
-            self,
-            query: str,
-            k: int = DEFAULT_K,
-            *,
-            filter: dict[str, str] | None = None,
-            **kwargs: Any,
-    ) -> list[tuple[Document, float]]:
-        """Run similarity search asynchronously and return distance scores
-
-        Args:
-            query (str): Query
-            k (int): Number of results to return. Defaults to 4.
-            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-
-        Returns:
-            List of Documents most similar along with relevance distance scores
-        """
-        query_embedding = self.embedding_function.embed_query(query)
-        return [
-            (document, similarity)
-            for document, similarity, _ in (
-                await self._asimilarity_search_by_vector_with_score(
-                    query_embedding, k, filter=filter, **kwargs
-                )
-            )
-        ]
-
-    def similarity_search_with_score(
-            self,
-            query: str,
-            k: int = DEFAULT_K,
-            *,
-            filter: dict[str, str] | None = None,
-            **kwargs: Any,
-    ) -> list[tuple[Document, float]]:
-        """Run similarity search synchronously and return distance scores
-
-        Args:
-            query (str): Query
-            k (int): Number of results to return. Defaults to 4.
-            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-
-        Returns:
-            List of Documents most similar along with relevance distance scores
-        """
-
-        async def _similarity_search_with_score() -> list[tuple[Document, float]]:
-            self.initialize()
-            return await self.asimilarity_search_with_score(
-                query, k, filter=filter, **kwargs
-            )
-
-        return asyncio.run(_similarity_search_with_score())
-
-    async def asimilarity_search_by_vector(
-            self,
-            embedding: list[float],
-            k: int = DEFAULT_K,
-            *,
-            filter: dict[str, str] | None = None,
-            **kwargs: Any,
+    def _filter_documents_from_result(
+        self,
+        search_result: list[tuple[Document, float, list[float]]],
+        embedding: list[float],
+        k: int = DEFAULT_K,
+        lambda_mult: float = 0.5,
     ) -> list[Document]:
-        """Run similarity search on query embedding asynchronously
-
-        Args:
-            embedding (list[float]): Query embedding
-            k (int): Number of results to return. Defaults to 4.
-            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-
-        Returns:
-            List of Documents most similar to the query
-        """
-        return [
-            document
-            for document, _, _ in await self._asimilarity_search_by_vector_with_score(
-                embedding, k, filter=filter, **kwargs
-            )
-        ]
-
-    def similarity_search_by_vector(
-            self,
-            embedding: list[float],
-            k: int = DEFAULT_K,
-            *,
-            filter: dict[str, str] | None = None,
-            **kwargs: Any,
-    ) -> list[Document]:
-        """Run similarity search on query embedding
-
-        Args:
-            embedding (list[float]): Query embedding
-            k (int): Number of results to return. Defaults to 4.
-            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-
-        Returns:
-            List of Documents most similar to the query
-        """
-
-        async def _similarity_search_by_vector() -> list[Document]:
-            self.initialize()
-            return await self.asimilarity_search_by_vector(
-                embedding, k, filter=filter, **kwargs
-            )
-
-        return asyncio.run(_similarity_search_by_vector())
-
-    async def asimilarity_search(
-            self,
-            query: str,
-            k: int = DEFAULT_K,
-            *,
-            filter: dict[str, str] | None = None,
-            **kwargs: Any,
-    ) -> list[Document]:
-        """Run similarity search on query asynchronously
-
-        Args:
-            query (str): Query
-            k (int): Number of results to return. Defaults to 4.
-            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-
-        Returns:
-            List of Documents most similar to the query
-        """
-        query_embedding = self.embedding_function.embed_query(query)
-        return await self.asimilarity_search_by_vector(
-            query_embedding, k, filter=filter, **kwargs
-        )
-
-    def similarity_search(
-            self,
-            query: str,
-            k: int = DEFAULT_K,
-            *,
-            filter: dict[str, str] | None = None,
-            **kwargs: Any,
-    ) -> list[Document]:
-        """Run similarity search on query
-
-        Args:
-            query (str): Query
-            k (int): Number of results to return. Defaults to 4.
-            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-
-        Returns:
-            List of Documents most similar to the query
-        """
-
-        async def _similarity_search() -> list[Document]:
-            self.initialize()
-            return await self.asimilarity_search(query, k, filter=filter, **kwargs)
-
-        return asyncio.run(_similarity_search())
-
-    async def amax_marginal_relevance_search_by_vector(
-            self,
-            embedding: list[float],
-            k: int = DEFAULT_K,
-            fetch_k: int = 20,
-            lambda_mult: float = 0.5,
-            *,
-            filter: dict[str, str] | None = None,
-            **kwargs: Any,
-    ) -> list[Document]:
-        """Return docs selected using the maximal marginal relevance.
-        Maximal marginal relevance optimizes for similarity to query AND diversity
-        among selected documents.
-
-        Args:
-            embedding: Embedding to look up documents similar to.
-            k: Number of Documents to return. Defaults to 4.
-            fetch_k: Number of Documents to fetch to pass to MMR algorithm.
-            lambda_mult: Number between 0 and 1 that determines the degree
-                        of diversity among the results with 0 corresponding
-                        to maximum diversity and 1 to minimum diversity.
-                        Defaults to 0.5.
-            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-
-        Returns:
-            List of Documents selected by maximal marginal relevance.
-        """
-
-        result = await self._asimilarity_search_by_vector_with_score(
-            embedding, fetch_k, filter=filter, **kwargs
-        )
-
         # extract only document from result
-        docs = [sub[0] for sub in result]
+        docs = [sub[0] for sub in search_result]
         # extract only embedding from result
-        embeddings = [sub[-1] for sub in result]
+        embeddings = [sub[-1] for sub in search_result]
 
         mmr_selected = maximal_marginal_relevance(
             np.array(embedding, dtype=np.float32),
@@ -583,170 +235,326 @@ class SurrealDBStore(VectorStore):
 
         return [docs[i] for i in mmr_selected]
 
-    def max_marginal_relevance_search_by_vector(
-            self,
-            embedding: list[float],
-            k: int = DEFAULT_K,
-            fetch_k: int = 20,
-            lambda_mult: float = 0.5,
-            *,
-            filter: dict[str, str] | None = None,
-            **kwargs: Any,
-    ) -> list[Document]:
-        """Return docs selected using the maximal marginal relevance.
+    # =========================================================================
+    # == Extended methods
+    # =========================================================================
 
-        Maximal marginal relevance optimizes for similarity to query AND diversity
-        among selected documents.
-
-        Args:
-            embedding: Embedding to look up documents similar to.
-            k: Number of Documents to return. Defaults to 4.
-            fetch_k: Number of Documents to fetch to pass to MMR algorithm.
-            lambda_mult: Number between 0 and 1 that determines the degree
-                        of diversity among the results with 0 corresponding
-                        to maximum diversity and 1 to minimum diversity.
-                        Defaults to 0.5.
-            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-
-        Returns:
-            List of Documents selected by maximal marginal relevance.
-        """
-
-        async def _max_marginal_relevance_search_by_vector() -> list[Document]:
-            self.initialize()
-            return await self.amax_marginal_relevance_search_by_vector(
-                embedding, k, fetch_k, lambda_mult, filter=filter, **kwargs
+    def add_texts(
+        self,
+        texts: Iterable[str],
+        metadatas: list[dict] | None = None,
+        *,
+        ids: list[str] | None = None,
+        **kwargs: Any,
+    ) -> list[str]:
+        embeddings = self.embedding.embed_documents(list(texts))
+        results = []
+        for idx, text in enumerate(texts):
+            record_id, data = self._build_text_data(
+                text,
+                embeddings[idx],
+                metadatas[idx] if metadatas is not None else None,
+                ids[idx] if ids is not None else None,
             )
+            results.append(self.connection.upsert(record_id, data))
+        result_ids = [x.get("id").id for x in results]
+        return result_ids
 
-        return asyncio.run(_max_marginal_relevance_search_by_vector())
+    @property
+    def embeddings(self) -> Embeddings | None:
+        return self.embedding if isinstance(self.embedding, Embeddings) else None
 
-    async def amax_marginal_relevance_search(
-            self,
-            query: str,
-            k: int = 4,
-            fetch_k: int = 20,
-            lambda_mult: float = 0.5,
-            *,
-            filter: dict[str, str] | None = None,
-            **kwargs: Any,
+    def delete(
+        self,
+        ids: list[str] | None = None,
+        **kwargs: Any,
+    ) -> bool | None:
+        try:
+            if ids is not None:
+                for id in ids:
+                    self.connection.delete(RecordID(self.table, id))
+            else:
+                self.connection.delete(self.table)
+        except Exception as _e:
+            return False
+        return True
+
+    def get_by_ids(self, ids: Sequence[str], /) -> list[Document]:
+        query_results = self.connection.query(
+            GET_BY_ID_QUERY,
+            {"table": self.table, "ids": ids},
+        )
+        return self._parse_documents(ids, query_results)
+
+    async def aget_by_ids(self, ids: Sequence[str], /) -> list[Document]:
+        query_results = await self.async_connection.query(
+            GET_BY_ID_QUERY,
+            {"table": self.table, "ids": ids},
+        )
+        return self._parse_documents(ids, query_results)
+
+    async def adelete(
+        self, ids: Optional[list[str]] = None, **kwargs: Any
+    ) -> Optional[bool]:
+        try:
+            if ids is not None:
+                coroutines = [
+                    self.async_connection.delete(RecordID(self.table, id)) for id in ids
+                ]
+                await asyncio.gather(*coroutines)
+            else:
+                await self.async_connection.delete(self.table)
+        except Exception as _e:
+            return False
+        return True
+
+    async def aadd_texts(
+        self,
+        texts: Iterable[str],
+        metadatas: list[dict] | None = None,
+        *,
+        ids: list[str] | None = None,
+        **kwargs: Any,
+    ) -> list[str]:
+        embeddings = self.embedding.embed_documents(list(texts))
+        coroutines = []
+        for idx, text in enumerate(texts):
+            record_id, data = self._build_text_data(
+                text,
+                embeddings[idx],
+                metadatas[idx] if metadatas is not None else None,
+                ids[idx] if ids is not None else None,
+            )
+            coroutines.append(self.async_connection.upsert(record_id, data))
+        results = await asyncio.gather(*coroutines)
+        result_ids = [x.get("id") for x in results]
+        return result_ids
+
+    def similarity_search(
+        self,
+        query: str,
+        k: int = 4,
+        *,
+        filter: dict[str, str] | None = None,
+        **kwargs: Any,
     ) -> list[Document]:
-        """Return docs selected using the maximal marginal relevance.
+        query_embedding = self.embedding.embed_query(query)
+        return self.similarity_search_by_vector(
+            query_embedding, k, filter=filter, **kwargs
+        )
 
-        Maximal marginal relevance optimizes for similarity to query AND diversity
-        among selected documents.
+    # TODO: implement
+    def _select_relevance_score_fn(self) -> Callable[[float], float]:
+        raise NotImplementedError
 
-        Args:
-            query: Text to look up documents similar to.
-            k: Number of Documents to return. Defaults to 4.
-            fetch_k: Number of Documents to fetch to pass to MMR algorithm.
-            lambda_mult: Number between 0 and 1 that determines the degree
-                        of diversity among the results with 0 corresponding
-                        to maximum diversity and 1 to minimum diversity.
-                        Defaults to 0.5.
-            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
+    def similarity_search_with_score(
+        self,
+        *,
+        query: str,
+        k: int = DEFAULT_K,
+        filter: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> list[tuple[Document, float]]:
+        # asimilarity_search_with_score
+        # TODO: HERE
+        ...
 
-        Returns:
-            List of Documents selected by maximal marginal relevance.
-        """
+    def _similarity_search_by_vector_with_score(
+        self,
+        embedding: list[float],
+        k: int = DEFAULT_K,
+        score_threshold: float = -1,
+        filter: dict[str, str] | None = None,
+    ):
+        query, args = self._build_search_query(embedding, k, score_threshold, filter)
+        results = self.connection.query(query, args)
+        return self._parse_results(results)
 
-        embedding = self.embedding_function.embed_query(query)
-        docs = await self.amax_marginal_relevance_search_by_vector(
+    def similarity_search_by_vector(
+        self,
+        embedding: list[float],
+        k: int = DEFAULT_K,
+        *,
+        filter: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> list[Document]:
+        return [
+            document
+            for document, _, _ in self._similarity_search_by_vector_with_score(
+                embedding, k, filter=filter, **kwargs
+            )
+        ]
+
+    def max_marginal_relevance_search(
+        self,
+        query: str,
+        k: int = DEFAULT_K,
+        fetch_k: int = 20,
+        lambda_mult: float = 0.5,
+        *,
+        filter: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> list[Document]:
+        embedding = self.embedding.embed_query(query)
+        docs = self.max_marginal_relevance_search_by_vector(
             embedding, k, fetch_k, lambda_mult, filter=filter, **kwargs
         )
         return docs
 
-    def max_marginal_relevance_search(
-            self,
-            query: str,
-            k: int = DEFAULT_K,
-            fetch_k: int = 20,
-            lambda_mult: float = 0.5,
-            *,
-            filter: dict[str, str] | None = None,
-            **kwargs: Any,
+    def max_marginal_relevance_search_by_vector(
+        self,
+        embedding: list[float],
+        k: int = DEFAULT_K,
+        fetch_k: int = 20,
+        lambda_mult: float = 0.5,
+        *,
+        filter: dict[str, str] | None = None,
+        **kwargs: Any,
     ) -> list[Document]:
-        """Return docs selected using the maximal marginal relevance.
-        Maximal marginal relevance optimizes for similarity to query AND diversity
-        among selected documents.
-
-        Args:
-            query: Text to look up documents similar to.
-            k: Number of Documents to return. Defaults to 4.
-            fetch_k: Number of Documents to fetch to pass to MMR algorithm.
-            lambda_mult: Number between 0 and 1 that determines the degree
-                        of diversity among the results with 0 corresponding
-                        to maximum diversity and 1 to minimum diversity.
-                        Defaults to 0.5.
-            filter (Optional[Dict[str, str]]): Filter by metadata. Defaults to None.
-
-        Returns:
-            List of Documents selected by maximal marginal relevance.
-        """
-
-        async def _max_marginal_relevance_search() -> list[Document]:
-            self.initialize()
-            return await self.amax_marginal_relevance_search(
-                query, k, fetch_k, lambda_mult, filter=filter, **kwargs
-            )
-
-        return asyncio.run(_max_marginal_relevance_search())
-
-    @classmethod
-    async def afrom_texts(
-            cls,
-            texts: list[str],
-            embedding: Embeddings,
-            metadatas: list[dict] | None = None,
-            **kwargs: Any,
-    ) -> "SurrealDBStore":
-        """Create SurrealDBStore from list of text asynchronously
-
-        Args:
-            texts (list[str]): list of text to vectorize and store
-            embedding (Optional[Embeddings]): Embedding function.
-            dburl (str): SurrealDB connection url
-                (default: "ws://localhost:8000/rpc")
-            ns (str): surrealdb namespace for the vector store.
-                (default: "langchain")
-            db (str): surrealdb database for the vector store.
-                (default: "database")
-            collection (str): surrealdb collection for the vector store.
-                (default: "documents")
-
-            (optional) db_user and db_pass: surrealdb credentials
-
-        Returns:
-            SurrealDBStore object initialized and ready for use."""
-
-        sdb = cls(embedding, **kwargs)
-        sdb.initialize()
-        await sdb.aadd_texts(texts, metadatas, **kwargs)
-        return sdb
+        result = self._similarity_search_by_vector_with_score(
+            embedding, fetch_k, filter=filter, **kwargs
+        )
+        return self._filter_documents_from_result(result, embedding, k, lambda_mult)
 
     @classmethod
     def from_texts(
-            cls,
-            texts: list[str],
-            embedding: Embeddings,
-            metadatas: list[dict] | None = None,
-            **kwargs: Any,
+        cls,
+        texts: list[str],
+        embedding: Embeddings,
+        metadatas: Optional[list[dict]] = None,
+        *,
+        ids: Optional[list[str]] = None,
+        connection: Surreal = None,
+        **kwargs: Any,
     ) -> "SurrealDBStore":
-        """Create SurrealDBStore from list of text
+        store = SurrealDBStore(embedding, connection)
+        store.add_texts(texts, metadatas)
+        return store
 
-        Args:
-            texts (list[str]): list of text to vectorize and store
-            embedding (Optional[Embeddings]): Embedding function.
-            dburl (str): SurrealDB connection url
-            ns (str): surrealdb namespace for the vector store.
-                (default: "langchain")
-            db (str): surrealdb database for the vector store.
-                (default: "database")
-            collection (str): surrealdb collection for the vector store.
-                (default: "documents")
+    @classmethod
+    async def afrom_texts(
+        cls,
+        texts: list[str],
+        embedding: Embeddings,
+        metadatas: Optional[list[dict]] = None,
+        *,
+        ids: Optional[list[str]] = None,
+        connection: AsyncSurreal = None,
+        **kwargs: Any,
+    ) -> "SurrealDBStore":
+        store = SurrealDBStore(embedding, None, async_connection=connection)
+        await store.aadd_texts(texts, metadatas)
+        return store
 
-            (optional) db_user and db_pass: surrealdb credentials
+    # =========================================================================
+    # =========================================================================
+    # =========================================================================
 
-        Returns:
-            SurrealDBStore object initialized and ready for use."""
-        sdb = asyncio.run(cls.afrom_texts(texts, embedding, metadatas, **kwargs))
-        return sdb
+    async def _asimilarity_search_by_vector_with_score(
+        self,
+        embedding: list[float],
+        k: int = DEFAULT_K,
+        *,
+        filter: dict[str, str] | None = None,
+        score_threshold: float = -1,
+    ) -> list[tuple[Document, float, list[float]]]:
+        query, args = self._build_search_query(embedding, k, score_threshold, filter)
+        results = await self.async_connection.query(query, args)
+        return self._parse_results(results)
+
+    async def asimilarity_search_with_relevance_scores(
+        self,
+        query: str,
+        k: int = DEFAULT_K,
+        *,
+        filter: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> list[tuple[Document, float]]:
+        query_embedding = self.embedding.embed_query(query)
+        # TODO: improve using asyncio.gather
+        return [
+            (document, similarity)
+            for document, similarity, _ in (
+                await self._asimilarity_search_by_vector_with_score(
+                    query_embedding, k, filter=filter, **kwargs
+                )
+            )
+        ]
+
+    def similarity_search_with_relevance_scores(
+        self,
+        query: str,
+        k: int = DEFAULT_K,
+        *,
+        filter: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> list[tuple[Document, float]]:
+        query_embedding = self.embedding.embed_query(query)
+        return [
+            (document, similarity)
+            for document, similarity, _ in (
+                self._similarity_search_by_vector_with_score(
+                    query_embedding, k, filter=filter, **kwargs
+                )
+            )
+        ]
+
+    async def asimilarity_search_by_vector(
+        self,
+        embedding: list[float],
+        k: int = DEFAULT_K,
+        *,
+        filter: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> list[Document]:
+        # TODO: improve using asyncio.gather
+        return [
+            document
+            for document, _, _ in await self._asimilarity_search_by_vector_with_score(
+                embedding, k, filter=filter, **kwargs
+            )
+        ]
+
+    async def asimilarity_search(
+        self,
+        query: str,
+        k: int = DEFAULT_K,
+        *,
+        filter: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> list[Document]:
+        query_embedding = self.embedding.embed_query(query)
+        return await self.asimilarity_search_by_vector(
+            query_embedding, k, filter=filter, **kwargs
+        )
+
+    async def amax_marginal_relevance_search_by_vector(
+        self,
+        embedding: list[float],
+        k: int = DEFAULT_K,
+        fetch_k: int = 20,
+        lambda_mult: float = 0.5,
+        *,
+        filter: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> list[Document]:
+        result = await self._asimilarity_search_by_vector_with_score(
+            embedding, fetch_k, filter=filter, **kwargs
+        )
+        return self._filter_documents_from_result(result, embedding, k, lambda_mult)
+
+    async def amax_marginal_relevance_search(
+        self,
+        query: str,
+        k: int = 4,
+        fetch_k: int = 20,
+        lambda_mult: float = 0.5,
+        *,
+        filter: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> list[Document]:
+        embedding = self.embedding.embed_query(query)
+        docs = await self.amax_marginal_relevance_search_by_vector(
+            embedding, k, fetch_k, lambda_mult, filter=filter, **kwargs
+        )
+        return docs

--- a/libs/community/langchain_community/vectorstores/surrealdb.py
+++ b/libs/community/langchain_community/vectorstores/surrealdb.py
@@ -1,7 +1,16 @@
 from __future__ import annotations
 
 import asyncio
-from typing import TYPE_CHECKING, Any, Callable, Iterable, Optional, Sequence, Union
+from dataclasses import KW_ONLY, dataclass, field
+from typing import (
+    TYPE_CHECKING,
+    Any,
+    Callable,
+    Iterable,
+    Optional,
+    Sequence,
+    Union,
+)
 
 import numpy as np
 from langchain_core.documents import Document
@@ -40,10 +49,27 @@ GET_BY_ID_QUERY = """
 #
 # ```sh
 # surreal start -u root -p root -l debug
-# make integration_tests TEST_FILE=tests/integration_tests/vectorstores/test_surrealdb.py. # noqa: E501
+# make integration_tests TEST_FILE=tests/integration_tests/vectorstores/test_surrealdb.py  # noqa: E501
 # make format
 # make lint
 # ```
+
+
+@dataclass
+class SurrealDocument:
+    _: KW_ONLY
+    id: RecordID = field(hash=False)
+    text: str
+    embedding: list[float]
+    similarity: float | None = None
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    def into(self) -> Document:
+        return Document(
+            id=self.id.id,
+            page_content=self.text,
+            metadata=self.metadata,
+        )
 
 
 class SurrealDBStore(VectorStore):
@@ -118,42 +144,44 @@ class SurrealDBStore(VectorStore):
             raise ValueError("No connection provided")
 
     def _build_text_data(
-        self, text: str, embedding: list[float], metadata: dict | None, id: str | None
-    ) -> tuple[str, dict]:
+        self,
+        text: str,
+        embedding: list[float],
+        metadata: dict | None,
+        with_id: str | None,
+    ) -> tuple[RecordID | None, dict]:
         preferred_id = None
         data = {"text": text, "embedding": embedding, "metadata": {}}
         if metadata is not None:
             data["metadata"] = metadata
             preferred_id = metadata.get("id")
-        if id is not None:
-            preferred_id = id
+        if with_id is not None:
+            preferred_id = with_id
         record_id = (
-            RecordID(self.table, preferred_id)
-            if preferred_id is not None
-            else self.table
+            RecordID(self.table, preferred_id) if preferred_id is not None else None
         )
         return record_id, data
 
-    def _parse_documents(
-        self, ids: Sequence[str], results: list[dict]
-    ) -> list[Document]:
-        docs = {
-            x.get("id").id: Document(
-                page_content=x.get("text"),
-                metadata=x.get("metadata", {}),
-                id=x.get("id").id,
-            )
-            for x in results
-        }
+    @staticmethod
+    def _parse_documents(ids: Sequence[str], results: list[dict]) -> list[Document]:
+        docs = {}
+        for x in results:
+            doc = SurrealDocument(**x).into()
+            docs[doc.id] = doc
         # sort docs in the same order as the passed in IDs
-        return [docs.get(key) for key in ids if docs.get(key) is not None]
+        result: list[Document] = []
+        for key in ids:
+            d = docs.get(str(key))
+            if d is not None:
+                result.append(d)
+        return result
 
     def _build_search_query(
         self,
         embedding: list[float],
         k: int,
         score_threshold: float,
-        custom_filter: dict,
+        custom_filter: dict[str, str] | None,
     ) -> tuple[str, dict]:
         args = {
             "table": self.table,
@@ -198,24 +226,23 @@ class SurrealDBStore(VectorStore):
 
         return query, args
 
+    @staticmethod
     def _parse_results(
-        self, results: list[dict]
+        results: list[dict],
     ) -> list[tuple[Document, float, list[float]]]:
-        return [
-            (
-                Document(
-                    page_content=doc["text"],
-                    metadata=doc.get("metadata", {}),
-                    id=doc.get("metadata").get("id"),
+        parsed = []
+        for raw in results:
+            parsed.append(
+                (
+                    SurrealDocument(**raw).into(),
+                    raw["similarity"],
+                    raw["embedding"],
                 ),
-                doc["similarity"],
-                doc["embedding"],
             )
-            for doc in results
-        ]
+        return parsed
 
+    @staticmethod
     def _filter_documents_from_result(
-        self,
         search_result: list[tuple[Document, float, list[float]]],
         embedding: list[float],
         k: int = DEFAULT_K,
@@ -247,6 +274,8 @@ class SurrealDBStore(VectorStore):
         ids: list[str] | None = None,
         **kwargs: Any,
     ) -> list[str]:
+        if self.connection is None:
+            raise ValueError("No connection provided")
         embeddings = self.embedding.embed_documents(list(texts))
         results = []
         for idx, text in enumerate(texts):
@@ -256,7 +285,10 @@ class SurrealDBStore(VectorStore):
                 metadatas[idx] if metadatas is not None else None,
                 ids[idx] if ids is not None else None,
             )
-            results.append(self.connection.upsert(record_id, data))
+            if record_id is not None:
+                results.append(self.connection.upsert(record_id, data))
+            else:
+                results.append(self.connection.insert(self.table, data))
         result_ids = [x.get("id").id for x in results]
         return result_ids
 
@@ -269,6 +301,8 @@ class SurrealDBStore(VectorStore):
         ids: list[str] | None = None,
         **kwargs: Any,
     ) -> bool | None:
+        if self.connection is None:
+            raise ValueError("No connection provided")
         try:
             if ids is not None:
                 for id in ids:
@@ -280,6 +314,8 @@ class SurrealDBStore(VectorStore):
         return True
 
     def get_by_ids(self, ids: Sequence[str], /) -> list[Document]:
+        if self.connection is None:
+            raise ValueError("No connection provided")
         query_results = self.connection.query(
             GET_BY_ID_QUERY,
             {"table": self.table, "ids": ids},
@@ -287,6 +323,8 @@ class SurrealDBStore(VectorStore):
         return self._parse_documents(ids, query_results)
 
     async def aget_by_ids(self, ids: Sequence[str], /) -> list[Document]:
+        if self.async_connection is None:
+            raise ValueError("No async connection provided")
         query_results = await self.async_connection.query(
             GET_BY_ID_QUERY,
             {"table": self.table, "ids": ids},
@@ -296,6 +334,8 @@ class SurrealDBStore(VectorStore):
     async def adelete(
         self, ids: Optional[list[str]] = None, **kwargs: Any
     ) -> Optional[bool]:
+        if self.async_connection is None:
+            raise ValueError("No async connection provided")
         try:
             if ids is not None:
                 coroutines = [
@@ -316,6 +356,8 @@ class SurrealDBStore(VectorStore):
         ids: list[str] | None = None,
         **kwargs: Any,
     ) -> list[str]:
+        if self.async_connection is None:
+            raise ValueError("No async connection provided")
         embeddings = self.embedding.embed_documents(list(texts))
         coroutines = []
         for idx, text in enumerate(texts):
@@ -325,7 +367,10 @@ class SurrealDBStore(VectorStore):
                 metadatas[idx] if metadatas is not None else None,
                 ids[idx] if ids is not None else None,
             )
-            coroutines.append(self.async_connection.upsert(record_id, data))
+            if record_id is not None:
+                coroutines.append(self.async_connection.upsert(record_id, data))
+            else:
+                coroutines.append(self.async_connection.insert(self.table, data))
         results = await asyncio.gather(*coroutines)
         result_ids = [x.get("id") for x in results]
         return result_ids
@@ -335,12 +380,12 @@ class SurrealDBStore(VectorStore):
         query: str,
         k: int = 4,
         *,
-        filter: dict[str, str] | None = None,
+        custom_filter: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> list[Document]:
         query_embedding = self.embedding.embed_query(query)
         return self.similarity_search_by_vector(
-            query_embedding, k, filter=filter, **kwargs
+            query_embedding, k, custom_filter=custom_filter, **kwargs
         )
 
     # TODO: implement
@@ -350,38 +395,32 @@ class SurrealDBStore(VectorStore):
     def similarity_search_with_score(
         self,
         *,
-        query: str,
-        k: int = DEFAULT_K,
-        filter: dict[str, str] | None = None,
-        **kwargs: Any,
-    ) -> list[tuple[Document, float]]:
-        # asimilarity_search_with_score
-        # TODO: HERE
-        ...
-
-    def _similarity_search_by_vector_with_score(
-        self,
         embedding: list[float],
         k: int = DEFAULT_K,
         score_threshold: float = -1,
-        filter: dict[str, str] | None = None,
-    ):
-        query, args = self._build_search_query(embedding, k, score_threshold, filter)
+        custom_filter: dict[str, str] | None = None,
+        **kwargs: Any,
+    ) -> list[tuple[Document, float]]:
+        if self.connection is None:
+            raise ValueError("No connection provided")
+        query, args = self._build_search_query(
+            embedding, k, score_threshold, custom_filter
+        )
         results = self.connection.query(query, args)
-        return self._parse_results(results)
+        return [(d, s) for d, s, _ in self._parse_results(results)]
 
     def similarity_search_by_vector(
         self,
         embedding: list[float],
         k: int = DEFAULT_K,
         *,
-        filter: dict[str, str] | None = None,
+        custom_filter: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> list[Document]:
         return [
             document
-            for document, _, _ in self._similarity_search_by_vector_with_score(
-                embedding, k, filter=filter, **kwargs
+            for document, _ in self.similarity_search_with_score(
+                embedding=embedding, k=k, custom_filter=custom_filter, **kwargs
             )
         ]
 
@@ -392,12 +431,12 @@ class SurrealDBStore(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         *,
-        filter: dict[str, str] | None = None,
+        custom_filter: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> list[Document]:
         embedding = self.embedding.embed_query(query)
         docs = self.max_marginal_relevance_search_by_vector(
-            embedding, k, fetch_k, lambda_mult, filter=filter, **kwargs
+            embedding, k, fetch_k, lambda_mult, custom_filter=custom_filter, **kwargs
         )
         return docs
 
@@ -408,11 +447,11 @@ class SurrealDBStore(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         *,
-        filter: dict[str, str] | None = None,
+        custom_filter: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> list[Document]:
         result = self._similarity_search_by_vector_with_score(
-            embedding, fetch_k, filter=filter, **kwargs
+            embedding, fetch_k, custom_filter=custom_filter, **kwargs
         )
         return self._filter_documents_from_result(result, embedding, k, lambda_mult)
 
@@ -450,15 +489,34 @@ class SurrealDBStore(VectorStore):
     # =========================================================================
     # =========================================================================
 
+    def _similarity_search_by_vector_with_score(
+        self,
+        embedding: list[float],
+        k: int = DEFAULT_K,
+        score_threshold: float = -1,
+        custom_filter: dict[str, str] | None = None,
+    ) -> list[tuple[Document, float, list[float]]]:
+        if self.connection is None:
+            raise ValueError("No connection provided")
+        query, args = self._build_search_query(
+            embedding, k, score_threshold, custom_filter
+        )
+        results = self.connection.query(query, args)
+        return self._parse_results(results)
+
     async def _asimilarity_search_by_vector_with_score(
         self,
         embedding: list[float],
         k: int = DEFAULT_K,
         *,
-        filter: dict[str, str] | None = None,
+        custom_filter: dict[str, str] | None = None,
         score_threshold: float = -1,
     ) -> list[tuple[Document, float, list[float]]]:
-        query, args = self._build_search_query(embedding, k, score_threshold, filter)
+        if self.async_connection is None:
+            raise ValueError("No async connection provided")
+        query, args = self._build_search_query(
+            embedding, k, score_threshold, custom_filter
+        )
         results = await self.async_connection.query(query, args)
         return self._parse_results(results)
 
@@ -467,7 +525,7 @@ class SurrealDBStore(VectorStore):
         query: str,
         k: int = DEFAULT_K,
         *,
-        filter: dict[str, str] | None = None,
+        custom_filter: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> list[tuple[Document, float]]:
         query_embedding = self.embedding.embed_query(query)
@@ -476,7 +534,7 @@ class SurrealDBStore(VectorStore):
             (document, similarity)
             for document, similarity, _ in (
                 await self._asimilarity_search_by_vector_with_score(
-                    query_embedding, k, filter=filter, **kwargs
+                    query_embedding, k, custom_filter=custom_filter, **kwargs
                 )
             )
         ]
@@ -486,7 +544,7 @@ class SurrealDBStore(VectorStore):
         query: str,
         k: int = DEFAULT_K,
         *,
-        filter: dict[str, str] | None = None,
+        custom_filter: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> list[tuple[Document, float]]:
         query_embedding = self.embedding.embed_query(query)
@@ -494,7 +552,7 @@ class SurrealDBStore(VectorStore):
             (document, similarity)
             for document, similarity, _ in (
                 self._similarity_search_by_vector_with_score(
-                    query_embedding, k, filter=filter, **kwargs
+                    query_embedding, k, custom_filter=custom_filter, **kwargs
                 )
             )
         ]
@@ -504,14 +562,14 @@ class SurrealDBStore(VectorStore):
         embedding: list[float],
         k: int = DEFAULT_K,
         *,
-        filter: dict[str, str] | None = None,
+        custom_filter: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> list[Document]:
         # TODO: improve using asyncio.gather
         return [
             document
             for document, _, _ in await self._asimilarity_search_by_vector_with_score(
-                embedding, k, filter=filter, **kwargs
+                embedding, k, custom_filter=custom_filter, **kwargs
             )
         ]
 
@@ -520,12 +578,12 @@ class SurrealDBStore(VectorStore):
         query: str,
         k: int = DEFAULT_K,
         *,
-        filter: dict[str, str] | None = None,
+        custom_filter: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> list[Document]:
         query_embedding = self.embedding.embed_query(query)
         return await self.asimilarity_search_by_vector(
-            query_embedding, k, filter=filter, **kwargs
+            query_embedding, k, custom_filter=custom_filter, **kwargs
         )
 
     async def amax_marginal_relevance_search_by_vector(
@@ -535,11 +593,11 @@ class SurrealDBStore(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         *,
-        filter: dict[str, str] | None = None,
+        custom_filter: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> list[Document]:
         result = await self._asimilarity_search_by_vector_with_score(
-            embedding, fetch_k, filter=filter, **kwargs
+            embedding, fetch_k, custom_filter=custom_filter, **kwargs
         )
         return self._filter_documents_from_result(result, embedding, k, lambda_mult)
 
@@ -550,11 +608,11 @@ class SurrealDBStore(VectorStore):
         fetch_k: int = 20,
         lambda_mult: float = 0.5,
         *,
-        filter: dict[str, str] | None = None,
+        custom_filter: dict[str, str] | None = None,
         **kwargs: Any,
     ) -> list[Document]:
         embedding = self.embedding.embed_query(query)
         docs = await self.amax_marginal_relevance_search_by_vector(
-            embedding, k, fetch_k, lambda_mult, filter=filter, **kwargs
+            embedding, k, fetch_k, lambda_mult, custom_filter=custom_filter, **kwargs
         )
         return docs

--- a/libs/community/langchain_community/vectorstores/surrealdb.py
+++ b/libs/community/langchain_community/vectorstores/surrealdb.py
@@ -277,7 +277,7 @@ class SurrealDBStore(VectorStore):
         if self.connection is None:
             raise ValueError("No connection provided")
         embeddings = self.embedding.embed_documents(list(texts))
-        results = []
+        result_ids = []
         for idx, text in enumerate(texts):
             record_id, data = self._build_text_data(
                 text,
@@ -286,10 +286,14 @@ class SurrealDBStore(VectorStore):
                 ids[idx] if ids is not None else None,
             )
             if record_id is not None:
-                results.append(self.connection.upsert(record_id, data))
+                inserted = self.connection.upsert(record_id, data)
             else:
-                results.append(self.connection.insert(self.table, data))
-        result_ids = [x.get("id").id for x in results]
+                inserted = self.connection.insert(self.table, data)
+            if isinstance(inserted, list):
+                for record in inserted:
+                    result_ids.append(record["id"].id)
+            else:
+                result_ids.append(inserted["id"].id)
         return result_ids
 
     @property
@@ -392,22 +396,40 @@ class SurrealDBStore(VectorStore):
     def _select_relevance_score_fn(self) -> Callable[[float], float]:
         raise NotImplementedError
 
-    def similarity_search_with_score(
+    def aux(
         self,
-        *,
         embedding: list[float],
+        *,
         k: int = DEFAULT_K,
         score_threshold: float = -1,
         custom_filter: dict[str, str] | None = None,
-        **kwargs: Any,
-    ) -> list[tuple[Document, float]]:
+    ) -> list[tuple[Document, float, list[float]]]:
         if self.connection is None:
             raise ValueError("No connection provided")
         query, args = self._build_search_query(
             embedding, k, score_threshold, custom_filter
         )
         results = self.connection.query(query, args)
-        return [(d, s) for d, s, _ in self._parse_results(results)]
+        return self._parse_results(results)
+
+    def similarity_search_with_score(
+        self,
+        query: str,
+        *,
+        k: int = DEFAULT_K,
+        score_threshold: float = -1,
+        custom_filter: dict[str, str] | None = None,
+    ) -> list[tuple[Document, float]]:
+        embedding = self.embedding.embed_query(query)
+        return [
+            (d, s)
+            for d, s, _ in self.aux(
+                embedding,
+                k=k,
+                score_threshold=score_threshold,
+                custom_filter=custom_filter,
+            )
+        ]
 
     def similarity_search_by_vector(
         self,
@@ -419,8 +441,8 @@ class SurrealDBStore(VectorStore):
     ) -> list[Document]:
         return [
             document
-            for document, _ in self.similarity_search_with_score(
-                embedding=embedding, k=k, custom_filter=custom_filter, **kwargs
+            for document, _, _ in self.aux(
+                embedding=embedding, k=k, custom_filter=custom_filter
             )
         ]
 

--- a/libs/community/langchain_community/vectorstores/surrealdb.py
+++ b/libs/community/langchain_community/vectorstores/surrealdb.py
@@ -133,9 +133,7 @@ class SurrealDBStore(VectorStore):
         """
         if self.async_connection is not None:
             loop = asyncio.get_event_loop()
-            loop.create_task(
-                self.async_connection.query(query)
-            )
+            loop.create_task(self.async_connection.query(query))
         elif self.connection is not None:
             self.connection.query(query)
         else:
@@ -261,12 +259,12 @@ class SurrealDBStore(VectorStore):
         return [docs[i] for i in mmr_selected]
 
     def _aux(
-            self,
-            embedding: list[float],
-            *,
-            k: int = DEFAULT_K,
-            score_threshold: float = -1,
-            custom_filter: dict[str, str] | None = None,
+        self,
+        embedding: list[float],
+        *,
+        k: int = DEFAULT_K,
+        score_threshold: float = -1,
+        custom_filter: dict[str, str] | None = None,
     ) -> list[tuple[Document, float, list[float]]]:
         if self.connection is None:
             raise ValueError("No connection provided")
@@ -315,12 +313,12 @@ class SurrealDBStore(VectorStore):
         return result_ids
 
     async def aadd_texts(
-            self,
-            texts: Iterable[str],
-            metadatas: list[dict] | None = None,
-            *,
-            ids: list[str] | None = None,
-            **kwargs: Any,
+        self,
+        texts: Iterable[str],
+        metadatas: list[dict] | None = None,
+        *,
+        ids: list[str] | None = None,
+        **kwargs: Any,
     ) -> list[str]:
         if self.async_connection is None:
             raise ValueError("No async connection provided")
@@ -365,7 +363,7 @@ class SurrealDBStore(VectorStore):
         return True
 
     async def adelete(
-            self, ids: Optional[list[str]] = None, **kwargs: Any
+        self, ids: Optional[list[str]] = None, **kwargs: Any
     ) -> Optional[bool]:
         if self.async_connection is None:
             raise ValueError("No async connection provided")

--- a/libs/community/tests/integration_tests/vectorstores/test_surrealdb.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_surrealdb.py
@@ -1,19 +1,30 @@
 from typing import Generator
 
 import pytest
-
-from langchain_core.documents import Document
-from langchain_core.embeddings import Embeddings
+from langchain_tests.integration_tests.vectorstores import VectorStoreIntegrationTests
 
 from langchain_community.vectorstores.surrealdb import SurrealDBStore
-from langchain_tests.integration_tests.vectorstores import VectorStoreIntegrationTests
 
 
 class TestSurrealDB(VectorStoreIntegrationTests):
+    @property
+    def has_async(self) -> bool:
+        return False
+
     @pytest.fixture
-    def vectorstore(self) -> Generator[SurrealDBStore, None, None]:
-        store = SurrealDBStore(embedding_function=self.get_embeddings(), db_user="root", db_pass="root", db="test",
-                               ns="test")
+    def vectorstore(self) -> Generator[SurrealDBStore, None, None]:  # type: ignore[override]
+        try:
+            from surrealdb import Surreal
+        except ImportError as e:
+            raise ImportError(
+                """Cannot import from surrealdb.
+                please install with `pip install surrealdb`."""
+            ) from e
+
+        conn = Surreal("ws://localhost:8000/rpc")
+        conn.signin({"username": "root", "password": "root"})
+        conn.use("langchain", "test")
+        store = SurrealDBStore(self.get_embeddings(), conn)
         store.delete()
         try:
             yield store
@@ -21,18 +32,35 @@ class TestSurrealDB(VectorStoreIntegrationTests):
             store.delete()
 
 
-def test_from_documents(embedding_openai: Embeddings) -> None:
-    """Test end to end construction and search."""
-    documents = [
-        Document(page_content="Dogs are tough.", metadata={"a": 1}),
-        Document(page_content="Cats have fluff.", metadata={"b": 1}),
-        Document(page_content="What is a sandwich?", metadata={"c": 1}),
-        Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
-    ]
-    vectorstore = SurrealDBStore.from_documents(
-        documents,
-        embedding_openai,
-    )
-    output = vectorstore.similarity_search("Sandwich", k=1)
-    assert output[0].page_content == "What is a sandwich?"
-    assert output[0].metadata["c"] == 1
+# FIXME: async test throws "got Future <Future pending> attached to a different
+#        loop" error
+# class TestSurrealDBAsync(VectorStoreIntegrationTests):
+#     @property
+#     def has_sync(self) -> bool:
+#         return False
+#
+#     @pytest.fixture
+#     def vectorstore(self) -> Generator[SurrealDBStore, None, None]:
+#         try:
+#             from surrealdb import AsyncSurreal
+#         except ImportError as e:
+#             raise ImportError(
+#                 """Cannot import from surrealdb.
+#                 please install with `pip install surrealdb`."""
+#             ) from e
+#
+#         async def _connect() -> AsyncSurreal:
+#             conn = AsyncSurreal("ws://localhost:8000/rpc")
+#             await conn.signin({"username": "root", "password": "root"})
+#             await conn.use("langchain", "test")
+#             return conn
+#
+#         async_conn = asyncio.run(_connect())
+#         store = SurrealDBStore(
+#           self.get_embeddings(), None, async_connection=async_conn
+#         )
+#         asyncio.run(store.adelete())
+#         try:
+#             yield store
+#         finally:
+#             asyncio.run(store.adelete())

--- a/libs/community/tests/integration_tests/vectorstores/test_surrealdb.py
+++ b/libs/community/tests/integration_tests/vectorstores/test_surrealdb.py
@@ -1,0 +1,38 @@
+from typing import Generator
+
+import pytest
+
+from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
+
+from langchain_community.vectorstores.surrealdb import SurrealDBStore
+from langchain_tests.integration_tests.vectorstores import VectorStoreIntegrationTests
+
+
+class TestSurrealDB(VectorStoreIntegrationTests):
+    @pytest.fixture
+    def vectorstore(self) -> Generator[SurrealDBStore, None, None]:
+        store = SurrealDBStore(embedding_function=self.get_embeddings(), db_user="root", db_pass="root", db="test",
+                               ns="test")
+        store.delete()
+        try:
+            yield store
+        finally:
+            store.delete()
+
+
+def test_from_documents(embedding_openai: Embeddings) -> None:
+    """Test end to end construction and search."""
+    documents = [
+        Document(page_content="Dogs are tough.", metadata={"a": 1}),
+        Document(page_content="Cats have fluff.", metadata={"b": 1}),
+        Document(page_content="What is a sandwich?", metadata={"c": 1}),
+        Document(page_content="That fence is purple.", metadata={"d": 1, "e": 2}),
+    ]
+    vectorstore = SurrealDBStore.from_documents(
+        documents,
+        embedding_openai,
+    )
+    output = vectorstore.similarity_search("Sandwich", k=1)
+    assert output[0].page_content == "What is a sandwich?"
+    assert output[0].metadata["c"] == 1


### PR DESCRIPTION
Updated the SurrealDB vectorestore integration.

- [x] integration tests: `make integration_tests TEST_FILE=tests/integration_tests/vectorstores/test_surrealdb.py`
- [x] other tests: jupyter notebook going to langchain's docs https://github.com/langchain-ai/langchain/pull/31199
- [x] format
- [x] lint