### PR TITLE
fix: replace invalid scenexplain algorithm

### DIFF
--- a/libs/community/langchain_community/utilities/scenexplain.py
+++ b/libs/community/langchain_community/utilities/scenexplain.py
@@ -35,7 +35,7 @@ class SceneXplainAPIWrapper(BaseModel):
             "data": [
                 {
                     "image": image,
-                    "algorithm": "Ember",
+                    "algorithm": "Jelly",
                     "languages": ["en"],
                 }
             ]


### PR DESCRIPTION
sceneXplain tool is not working at the moment. Algorithm Ember no longer exists for https://api.scenex.jina.ai/v1/describe API, the recommended one is Jelly now