### PR TITLE
fix: enable forced with_structured_output in ChatTongyi

### DIFF
--- a/libs/community/langchain_community/chat_models/tongyi.py
+++ b/libs/community/langchain_community/chat_models/tongyi.py
@@ -892,7 +892,15 @@ class ChatTongyi(BaseChatModel):
         if kwargs:
             raise ValueError(f"Received unsupported arguments {kwargs}")
         is_pydantic_schema = isinstance(schema, type) and is_basemodel_subclass(schema)
-        llm = self.bind_tools([schema])
+        llm = self.bind_tools(
+            [schema], 
+            tool_choice={
+                "type": "function",
+                "function": {
+                    "name": schema.__name__
+                }
+            }
+        )
         if is_pydantic_schema:
             output_parser: OutputParserLike = PydanticToolsParser(
                 tools=[schema],  # type: ignore[list-item]


### PR DESCRIPTION
## Description:
Currently, the `with_structured_output` method in `ChatTongyi` uses:
```python
llm = self.bind_tools([schema])
```
However, this does not guarantee that the model will invoke the function call, which may lead to a plain `None` response instead of an instance of `MyModel`, as demonstrated in the example below:
```python
llm = ChatTongyi(
    ...
)

class MyModel(BaseModel):
    name: Optional[str] =  Field(None, description="name, return None if not found")
    age: Optional[int] = Field(None, description="age, return None if not found")

llm = llm.with_structured_output(MyModel)

response = llm.invoke("hi!!")

# output: None
# expected output: MyModel(name=None, age=None)
```

According to the [Qwen document](https://www.alibabacloud.com/help/en/model-studio/use-qwen-by-calling-api), we can force the model to invoke a function by specifying:
```python
tool_choice={"type": "function", "function": {"name": function_name}}
```

To ensure the reliability and consistency of structured outputs, I have added support for this feature.

## Dependencies:
- N/A