### PR TITLE
fix: fix scenexplain tool

### DIFF
--- a/libs/community/extended_testing_deps.txt
+++ b/libs/community/extended_testing_deps.txt
@@ -105,3 +105,4 @@ websocket>=0.2.1,<1
 writer-sdk>=1.2.0
 yandexcloud==0.144.0
 unstructured[pdf]>=0.15
+pyopenssl>=24.2.0

--- a/libs/community/extended_testing_deps.txt
+++ b/libs/community/extended_testing_deps.txt
@@ -106,4 +106,3 @@ websocket>=0.2.1,<1
 writer-sdk>=1.2.0
 yandexcloud==0.144.0
 unstructured[pdf]>=0.15
-pyopenssl>=24.2.0

--- a/libs/community/langchain_community/tools/scenexplain/tool.py
+++ b/libs/community/langchain_community/tools/scenexplain/tool.py
@@ -21,8 +21,9 @@ class SceneXplainTool(BaseTool):
     name: str = "image_explainer"
     description: str = (
         "An Image Captioning Tool: Use this tool to generate a detailed caption "
-        "for an image. The input can be an image file of any format, and "
-        "the output will be a text description that covers every detail of the image."
+        "for an image. The input can be an image file of any format such as a URL or "
+        "a local file path, no other text, and the output will be a text description "
+        "that covers every detail of the image."
     )
     api_wrapper: SceneXplainAPIWrapper = Field(default_factory=SceneXplainAPIWrapper)
 


### PR DESCRIPTION
The current scenexplain tool doesn't work and can't properly find/fetch the image URL/path due to the description. This is to fix it so that it can get the image URL properly.