### PR TITLE
Deprecating hugging face implementation in langchain_community

### DIFF
--- a/libs/community/langchain_community/embeddings/huggingface.py
+++ b/libs/community/langchain_community/embeddings/huggingface.py
@@ -408,7 +408,7 @@ class HuggingFaceBgeEmbeddings(BaseModel, Embeddings):
 @deprecated(
     since="0.2.2",
     removal="1.0",
-    alternative_import="langchain_huggingface.HuggingFaceEmbeddings",
+    alternative_import="langchain_huggingface.HuggingFaceEndpointEmbeddings",
 )
 class HuggingFaceInferenceAPIEmbeddings(BaseModel, Embeddings):
     """Embed texts using the HuggingFace API.

--- a/libs/community/langchain_community/embeddings/huggingface.py
+++ b/libs/community/langchain_community/embeddings/huggingface.py
@@ -130,6 +130,11 @@ class HuggingFaceEmbeddings(BaseModel, Embeddings):
         return self.embed_documents([text])[0]
 
 
+@deprecated(
+    since="0.2.2",
+    removal="1.0",
+    alternative_import="langchain_huggingface.HuggingFaceEmbeddings",
+)
 class HuggingFaceInstructEmbeddings(BaseModel, Embeddings):
     """Wrapper around sentence_transformers embedding models.
 
@@ -400,6 +405,11 @@ class HuggingFaceBgeEmbeddings(BaseModel, Embeddings):
         return embedding.tolist()
 
 
+@deprecated(
+    since="0.2.2",
+    removal="1.0",
+    alternative_import="langchain_huggingface.HuggingFaceEmbeddings",
+)
 class HuggingFaceInferenceAPIEmbeddings(BaseModel, Embeddings):
     """Embed texts using the HuggingFace API.
 


### PR DESCRIPTION
This helps with [Issue 29910](https://github.com/langchain-ai/langchain/issues/29910) by pointing to the equivalent implementation in the partners package. 

In a nutshell the huggingface embedding implementation in the partner packages should be standard going forward and the implementation in the community package is being deprecated.