### PR TITLE
vectorstores[azure_search]: fix regression in 0.3.24 

### DIFF
--- a/libs/community/langchain_community/vectorstores/azuresearch.py
+++ b/libs/community/langchain_community/vectorstores/azuresearch.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import asyncio
 import base64
+import copy
 import itertools
 import json
 import logging
@@ -375,7 +376,9 @@ class AzureSearch(VectorStore):
             default_fields=default_fields,
             user_agent=user_agent,
             cors_options=cors_options,
-            additional_search_client_options=additional_search_client_options,
+            additional_search_client_options=copy.deepcopy(
+                additional_search_client_options
+            ),
             azure_credential=azure_credential,
         )
 

--- a/libs/community/tests/unit_tests/vectorstores/test_azure_search.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_azure_search.py
@@ -194,6 +194,11 @@ def test_additional_search_options() -> None:
 
 @pytest.mark.requires("azure.search.documents")
 def test_additional_search_options_retry_policy() -> None:
+    """
+    Reproduces bug captured in:
+    https://github.com/langchain-ai/langchain-community/issues/76
+    """
+    from azure.core.exceptions import HttpResponseError
     from azure.core.pipeline.policies import RetryPolicy
     from azure.search.documents.indexes import SearchIndexClient
 
@@ -214,7 +219,10 @@ def test_additional_search_options_retry_policy() -> None:
         )
         assert vector_store.client is not None
 
-        list(vector_store.client.search())
+        # Bug previously raised an:
+        #  AttributeError: 'coroutine' object has no attribute 'http_response'
+        with pytest.raises(HttpResponseError):
+            list(vector_store.client.search())
 
 
 @pytest.mark.requires("azure.search.documents")


### PR DESCRIPTION
Fixes #76 

- This fixes regression which started in #50 
- Shared dict gets mutated by async code, even if unused
- I put a gross `deepcopy()` to avoid this data leak; a better solution should be investigated