### PR TITLE
fix: telegram multiformat

### DIFF
--- a/libs/community/langchain_community/chat_loaders/telegram.py
+++ b/libs/community/langchain_community/chat_loaders/telegram.py
@@ -102,6 +102,8 @@ class TelegramChatLoader(BaseChatLoader):
             text = message.get("text", "")
             timestamp = message.get("date", "")
             from_name = message.get("from", "")
+            if from_name is None:
+                from_name = "Deleted Account"
 
             results.append(
                 HumanMessage(

--- a/libs/community/langchain_community/chat_loaders/utils.py
+++ b/libs/community/langchain_community/chat_loaders/utils.py
@@ -23,12 +23,12 @@ def merge_chat_runs_in_session(
     messages: List[BaseMessage] = []
     for message in chat_session["messages"]:
         if isinstance(message.content, list):
-            for obj in message.content:
-                text = ""
-                if isinstance(obj, dict):
-                    text += obj.get("text", None)
+            text = ""
+            for content in message.content:
+                if isinstance(content, dict):
+                    text += content.get("text", None)
                 else:
-                    text += obj
+                    text += content
             message.content = text
         if not isinstance(message.content, str):
             raise ValueError(

--- a/libs/community/langchain_community/chat_loaders/utils.py
+++ b/libs/community/langchain_community/chat_loaders/utils.py
@@ -22,6 +22,14 @@ def merge_chat_runs_in_session(
     """
     messages: List[BaseMessage] = []
     for message in chat_session["messages"]:
+        if isinstance(message.content, list):
+            for obj in message.content:
+                text = ""
+                if isinstance(obj, dict):
+                    text += obj.get("text", None)
+                else:
+                    text += obj
+            message.content = text
         if not isinstance(message.content, str):
             raise ValueError(
                 "Chat Loaders only support messages with content type string, "

--- a/libs/community/tests/unit_tests/chat_loaders/data/telegram_chat_json/result.json
+++ b/libs/community/tests/unit_tests/chat_loaders/data/telegram_chat_json/result.json
@@ -62,6 +62,56 @@
      "text": "you will not trick me this time"
     }
    ]
+  },
+  {
+   "id": 5,
+   "type": "message",
+   "date": "2023-08-23T13:16:20",
+   "date_unixtime": "1692821780",
+   "from": "Batman & Robin",
+   "from_id": "user6565661032",
+   "text": [
+    "this is bold text: ",
+    {
+     "type": "bold",
+     "text": "BOLD TEXT"
+    }
+   ],
+   "text_entities": [
+    {
+     "type": "plain",
+     "text": "this is bold text: "
+    },
+    {
+     "type": "bold",
+     "text": "BOLD TEXT"
+    }
+   ]
+  },
+  {
+   "id": 6,
+   "type": "message",
+   "date": "2023-08-23T13:17:10",
+   "date_unixtime": "1692821830",
+   "from": "Jimmeny Marvelton",
+   "from_id": "user123450513",
+   "text": [
+    "this is an email: ",
+    {
+     "type": "email",
+     "text": "admin@example.com"
+    }
+   ],
+   "text_entities": [
+    {
+     "type": "plain",
+     "text": "this is an email: "
+    },
+    {
+     "type": "email",
+     "text": "admin@example.com"
+    }
+   ]
   }
  ]
 }

--- a/libs/community/tests/unit_tests/chat_loaders/test_telegram.py
+++ b/libs/community/tests/unit_tests/chat_loaders/test_telegram.py
@@ -69,6 +69,20 @@ def _check_telegram_chat_loader(path: str) -> None:
                     "events": [{"message_time": "23.08.2023 13:15:35 UTC-08:00"}],
                 },
             ),
+            AIMessage(
+                content="this is bold text: BOLD TEXT",
+                additional_kwargs={
+                    "sender": "Batman & Robin",
+                    "events": [{"message_time": "23.08.2023 13:16:20 UTC-08:00"}],
+                },
+            ),
+            HumanMessage(
+                content="this is an email: admin@example.com",
+                additional_kwargs={
+                    "sender": "Jimmeny Marvelton",
+                    "events": [{"message_time": "23.08.2023 13:17:10 UTC-08:00"}],
+                },
+            )
         ]
         _assert_messages_are_equal(session["messages"], expected_content)
 

--- a/libs/community/tests/unit_tests/chat_loaders/test_telegram.py
+++ b/libs/community/tests/unit_tests/chat_loaders/test_telegram.py
@@ -82,7 +82,7 @@ def _check_telegram_chat_loader(path: str) -> None:
                     "sender": "Jimmeny Marvelton",
                     "events": [{"message_time": "23.08.2023 13:17:10 UTC-08:00"}],
                 },
-            )
+            ),
         ]
         _assert_messages_are_equal(session["messages"], expected_content)
 


### PR DESCRIPTION
This PR adds:

- support for messages that contain special objects such as links, phone, email, formatting. `message.content` can be in the form of a list which raises the error when checking for type string
- support for chats with deleted accounts by adding the value "Deleted Account" if `from` field is empty. This is an issue when trying to call `map_ai_messages()` as it won't be able to determine the sender resulting in no `AIMessage`

Reproducing the bug:

1. export a Telegram chat that contains links or other special formatting like bold text in JSON format
2. import and run the function `TelegramChatLoader()` - it will throw the error `Chat Loaders only support messages with content type string, got ...`