### PR TITLE
Fix the issue of parallel tool calls in ChatTongyi when incremental streaming output is enabled.

### DIFF
--- a/libs/community/langchain_community/chat_models/tongyi.py
+++ b/libs/community/langchain_community/chat_models/tongyi.py
@@ -108,7 +108,7 @@ def convert_dict_to_message(
                                 "name": value["function"].get("name"),
                                 "args": value["function"].get("arguments"),
                                 "id": value.get("id"),
-                                # Tongyi does not respond with index,
+                                #  Tongyi does not respond with index,
                                 # use index in the list instead
                                 "index": value.get("index", index),
                             }

--- a/libs/community/langchain_community/chat_models/tongyi.py
+++ b/libs/community/langchain_community/chat_models/tongyi.py
@@ -110,7 +110,7 @@ def convert_dict_to_message(
                                 "id": value.get("id"),
                                 # Tongyi does not respond with index,
                                 # use index in the list instead
-                                "index": index,
+                                "index": value.get("index", index),
                             }
                         )
                     except KeyError:
@@ -758,7 +758,7 @@ class ChatTongyi(BaseChatModel):
             messages=messages, stop=stop, stream=True, **kwargs
         )
         async for stream_resp, is_last_chunk in agenerate_with_last_element_mark(
-            self.astream_completion_with_retry(**params)
+            self.astream_completion_with_retry(**params)  # type: ignore[reportCallIssue]
         ):
             chunk = ChatGenerationChunk(
                 **self._chat_generation_from_qwen_resp(

--- a/libs/community/langchain_community/chat_models/tongyi.py
+++ b/libs/community/langchain_community/chat_models/tongyi.py
@@ -108,7 +108,7 @@ def convert_dict_to_message(
                                 "name": value["function"].get("name"),
                                 "args": value["function"].get("arguments"),
                                 "id": value.get("id"),
-                                #  Tongyi does not respond with index,
+                                # While Tongyi does not respond with index,
                                 # use index in the list instead
                                 "index": value.get("index", index),
                             }


### PR DESCRIPTION

In the latest Alibaba Cloud Qwen models, such as Qwen-Plus-latest and Qwen3-235B-A22B, these models must use incremental_output for streaming output in reasoning mode. However, there will be issues when using parallel_tool_calls at the same time. The sample code is as follows:

```python
import asyncio
from langchain_community.chat_models import ChatTongyi
from langchain_core.tools import tool


@tool
def get_weather(city: str):
    """Get the weather of a city"""
    return f"{city} is sunny"


model = ChatTongyi(
    model="qwen-plus-latest",
    streaming=True,
    model_kwargs={"incremental_output": True, "enable_thinking": True},
)  # pyright:ignore

model = model.bind_tools([get_weather])

print(
    model.invoke(
        "Check the weather in San Francisco and New York", parallel_tool_calls=True
    )
)

```


![image](https://github.com/user-attachments/assets/8ed24300-aa37-43c7-b781-fa96b8005a38)


The following output will be generated, showing that there is a problem with tool_calls.


```base
 tool_calls=[{'name': 'get_weatherget_weather', 'args': {'city': 'San Francisco'}, 'id': 'call_4835d51c1d444b0886ade5call_5a2c75ffc0ca4beb9a9eef', 'type': 'tool_call'}]
```

It should originally contain two tools' JSON schemas, but there is only one, and even that one is problematic. The specific reason is that the same field in the two JSON schemas has been merged. This is clearly an issue.


The reason is that this source code uses the array's subscript as the index, but in the case of incremental streaming output, this index is almost always 0. That is, this code does not adapt well to incremental streaming output.
image.png

However, the documentation of BaiLian Qwen already states that it will return the corresponding index, https://help.aliyun.com/zh/model-studio/deep-thinking

![image](https://github.com/user-attachments/assets/172432c8-ef13-450d-a6fb-68e16c7b6dae)


Therefore, the following modifications were made, resulting in this PR.
```python
  tool_calls.append(
                            {
                                "name": value["function"].get("name"),
                                "args": value["function"].get("arguments"),
                                "id": value.get("id"),
                                # Tongyi does not respond with index,
                                # use index in the list instead
                                "index": value.get("index", index),
                            }
                        )
```
After correction, it was found to be successfully parsed.
![image](https://github.com/user-attachments/assets/c35af748-7396-42f4-bb05-f601464ee2f0)
