### PR TITLE
Update BATCH_SIZE constants and expand test coverage for DashScope embeddings

### DIFF
--- a/libs/community/langchain_community/embeddings/dashscope.py
+++ b/libs/community/langchain_community/embeddings/dashscope.py
@@ -23,7 +23,7 @@ from tenacity import (
 
 logger = logging.getLogger(__name__)
 
-BATCH_SIZE = {"text-embedding-v1": 25, "text-embedding-v2": 25, "text-embedding-v3": 6}
+BATCH_SIZE = {"text-embedding-v1": 25, "text-embedding-v2": 25, "text-embedding-v3": 10, "text-embedding-v4": 10}
 
 
 def _create_retry_decorator(embeddings: DashScopeEmbeddings) -> Callable[[Any], Any]:

--- a/libs/community/tests/integration_tests/embeddings/test_dashscope.py
+++ b/libs/community/tests/integration_tests/embeddings/test_dashscope.py
@@ -4,17 +4,23 @@ import numpy as np
 
 from langchain_community.embeddings.dashscope import DashScopeEmbeddings
 
+MODELS = [
+    ("text-embedding-v1", 1536),
+    ("text-embedding-v2", 1536),
+    ("text-embedding-v3", 1024),
+    ("text-embedding-v4", 1024),
+]
 
-def test_dashscope_embedding_documents() -> None:
+def test_dashscope_embedding_documents(model: str, dimensions: int) -> None:
     """Test dashscope embeddings."""
     documents = ["foo bar"]
-    embedding = DashScopeEmbeddings(model="text-embedding-v1")
+    embedding = DashScopeEmbeddings(model=model)
     output = embedding.embed_documents(documents)
     assert len(output) == 1
-    assert len(output[0]) == 1536
+    assert len(output[0]) == dimensions
 
 
-def test_dashscope_embedding_documents_multiple() -> None:
+def test_dashscope_embedding_documents_multiple(model: str, dimensions: int) -> None:
     """Test dashscope embeddings."""
     documents = [
         "foo bar",
@@ -46,40 +52,41 @@ def test_dashscope_embedding_documents_multiple() -> None:
         "foo23",
         "foo24",
     ]
-    embedding = DashScopeEmbeddings(model="text-embedding-v1")
+    embedding = DashScopeEmbeddings(model=model)
     output = embedding.embed_documents(documents)
     assert len(output) == 28
-    assert len(output[0]) == 1536
-    assert len(output[1]) == 1536
-    assert len(output[2]) == 1536
+    assert len(output[0]) == dimensions
+    assert len(output[1]) == dimensions
+    assert len(output[2]) == dimensions
 
 
-def test_dashscope_embedding_query() -> None:
+def test_dashscope_embedding_query(model: str, dimensions: int) -> None:
     """Test dashscope embeddings."""
     document = "foo bar"
-    embedding = DashScopeEmbeddings(model="text-embedding-v1")
+    embedding = DashScopeEmbeddings(model=model)
     output = embedding.embed_query(document)
-    assert len(output) == 1536
+    assert len(output) == dimensions
 
 
-def test_dashscope_embedding_with_empty_string() -> None:
+def test_dashscope_embedding_with_empty_string(model: str, dimensions: int) -> None:
     """Test dashscope embeddings with empty string."""
     import dashscope
 
     document = ["", "abc"]
-    embedding = DashScopeEmbeddings(model="text-embedding-v1")
+    embedding = DashScopeEmbeddings(model=model)
     output = embedding.embed_documents(document)
     assert len(output) == 2
-    assert len(output[0]) == 1536
+    assert len(output[0]) == dimensions
     expected_output = dashscope.TextEmbedding.call(
-        input="", model="text-embedding-v1", text_type="document"
+        input="", model=model, text_type="document"
     ).output["embeddings"][0]["embedding"]
     assert np.allclose(output[0], expected_output)
-    assert len(output[1]) == 1536
+    assert len(output[1]) == dimensions
 
 
 if __name__ == "__main__":
-    test_dashscope_embedding_documents()
-    test_dashscope_embedding_documents_multiple()
-    test_dashscope_embedding_query()
-    test_dashscope_embedding_with_empty_string()
+    for model, dimensions in MODELS:
+        test_dashscope_embedding_documents(model, dimensions)
+        test_dashscope_embedding_documents_multiple(model, dimensions)
+        test_dashscope_embedding_query(model, dimensions)
+        test_dashscope_embedding_with_empty_string(model, dimensions)


### PR DESCRIPTION
This PR introduces the following improvements for DashScope embeddings:

### Changes
1. **Updated `BATCH_SIZE` constants**  
   - Modified the `BATCH_SIZE` dictionary to reflect the latest maximum batch size values for dashscope models
   - Added new model `text-embedding-v4`

2. **Enhanced test coverage**  
   - Refactored the existing test case to validate **all models** in `BATCH_SIZE`  
   - Previously only tested a single model; now comprehensively verifies all entries

### Key Issue Resolved
- Without update `BATCH_SIZE`, **the new tests fail with ValueError**:  
  `"batch size is invalid, it should not be larger than 10"`  
  This occurs because:
   - New tests validate all models (not just the previously tested one)
   - The new model `text-embedding-v4` uses default batch size 25, higher than 10
- After updating `BATCH_SIZE`:
   - All models pass validation checks
   - New comprehensive tests confirm correct batch sizes and dimensions for every model

### Why these changes?
- Maintains accuracy as dashscope's model specifications evolve
- Prevents potential batch processing errors due to outdated limits
- Significantly improves test reliability by covering all model configurations

---

ok, the description was generated by AI, actually I just wanna try the new embedding model...