### PR TITLE
Update dashscope: Add dimensions support for DashScopeEmbeddings

### DIFF
--- a/libs/community/langchain_community/embeddings/dashscope.py
+++ b/libs/community/langchain_community/embeddings/dashscope.py
@@ -23,7 +23,12 @@ from tenacity import (
 
 logger = logging.getLogger(__name__)
 
-BATCH_SIZE = {"text-embedding-v1": 25, "text-embedding-v2": 25, "text-embedding-v3": 6}
+BATCH_SIZE = {
+    "text-embedding-v1": 25,
+    "text-embedding-v2": 25,
+    "text-embedding-v4": 25,
+    "text-embedding-v3": 6,
+}
 
 
 def _create_retry_decorator(embeddings: DashScopeEmbeddings) -> Callable[[Any], Any]:
@@ -47,6 +52,11 @@ def embed_with_retry(embeddings: DashScopeEmbeddings, **kwargs: Any) -> Any:
 
     @retry_decorator
     def _embed_with_retry(**kwargs: Any) -> Any:
+        # If dimension is not passed in kwargs, use the one from the instance.
+        # The Dashscope SDK's parameter is `dimension`.
+        if "dimension" not in kwargs and embeddings.dimensions is not None:
+            kwargs["dimension"] = embeddings.dimensions
+
         result = []
         i = 0
         input_data = kwargs["input"]
@@ -54,7 +64,7 @@ def embed_with_retry(embeddings: DashScopeEmbeddings, **kwargs: Any) -> Any:
         batch_size = BATCH_SIZE.get(kwargs["model"], 25)
         while i < input_len:
             kwargs["input"] = (
-                input_data[i : i + batch_size]
+                input_data[i: i + batch_size]
                 if isinstance(input_data, list)
                 else input_data
             )
@@ -99,19 +109,37 @@ class DashScopeEmbeddings(BaseModel, Embeddings):
 
             from langchain_community.embeddings.dashscope import DashScopeEmbeddings
             embeddings = DashScopeEmbeddings(
-                model="text-embedding-v1",
+                model="text-embedding-v4",
             )
             text = "This is a test query."
+            query_result = embeddings.embed_query(text)
+
+    Example with custom dimensions:
+        .. code-block:: python
+
+            embeddings = DashScopeEmbeddings(
+                model="text-embedding-v4",
+                dimensions=256,
+            )
+            text = "This is a test query with custom dimensions."
             query_result = embeddings.embed_query(text)
 
     """
 
     client: Any = None  #: :meta private:
     """The DashScope client."""
-    model: str = "text-embedding-v1"
+    model: str = "text-embedding-v4"
     dashscope_api_key: Optional[str] = None
     max_retries: int = 5
     """Maximum number of retries to make when generating."""
+    dimensions: Optional[int] = None
+    """The dimension of the embedding vector.
+
+    Only supported for ``text-embedding-v3`` and ``text-embedding-v4`` models.
+    - ``text-embedding-v4`` supports [2048, 1536, 1024, 768, 512, 256, 128, 64].
+    - ``text-embedding-v3`` supports [1024, 768, 512, 256, 128, 64].
+    If not specified, the API default of 1024 is used.
+    """
 
     model_config = ConfigDict(
         extra="forbid",
@@ -120,49 +148,59 @@ class DashScopeEmbeddings(BaseModel, Embeddings):
     @model_validator(mode="before")
     @classmethod
     def validate_environment(cls, values: Dict) -> Any:
-        import dashscope
-
         """Validate that api key and python package exists in environment."""
         values["dashscope_api_key"] = get_from_dict_or_env(
             values, "dashscope_api_key", "DASHSCOPE_API_KEY"
         )
-        dashscope.api_key = values["dashscope_api_key"]
         try:
             import dashscope
 
+            dashscope.api_key = values["dashscope_api_key"]
             values["client"] = dashscope.TextEmbedding
         except ImportError:
             raise ImportError(
                 "Could not import dashscope python package. "
                 "Please install it with `pip install dashscope`."
             )
+
+        # Validate that dimensions parameter is only used with supported models
+        if values.get("dimensions") is not None:
+            model = values.get("model", "text-embedding-v4")
+            if model not in ["text-embedding-v3", "text-embedding-v4"]:
+                raise ValueError(
+                    f"Custom `dimensions` are only supported for 'text-embedding-v3' and "
+                    f"'text-embedding-v4'. You are using '{model}'."
+                )
+
         return values
 
-    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+    def embed_documents(self, texts: List[str], **kwargs) -> List[List[float]]:
         """Call out to DashScope's embedding endpoint for embedding search docs.
 
         Args:
             texts: The list of texts to embed.
+            **kwargs: Additional keyword arguments to pass to the API.
 
         Returns:
             List of embeddings, one for each text.
         """
         embeddings = embed_with_retry(
-            self, input=texts, text_type="document", model=self.model
+            self, input=texts, text_type="document", model=self.model, **kwargs
         )
         embedding_list = [item["embedding"] for item in embeddings]
         return embedding_list
 
-    def embed_query(self, text: str) -> List[float]:
+    def embed_query(self, text: str, **kwargs) -> List[float]:
         """Call out to DashScope's embedding endpoint for embedding query text.
 
         Args:
             text: The text to embed.
+            **kwargs: Additional keyword arguments to pass to the API.
 
         Returns:
             Embedding for the text.
         """
         embedding = embed_with_retry(
-            self, input=text, text_type="query", model=self.model
+            self, input=text, text_type="query", model=self.model, **kwargs
         )[0]["embedding"]
         return embedding


### PR DESCRIPTION

### PR Description

This PR adds support for the `dimensions` parameter to the `DashScopeEmbeddings` class, allowing users to specify the output vector dimension when using compatible models.

**Motivation:**

The latest DashScope embedding models (`text-embedding-v3` and `text-embedding-v4`) provide the capability to select from a range of vector dimensions. This feature offers users valuable flexibility to balance embedding performance against computational/storage costs for their specific use case. This PR exposes this functionality within LangChain, making the `DashScopeEmbeddings` integration more powerful and aligned with the provider's API.

**Key Changes:**

1.  **Added `dimensions` Parameter**: An optional `dimensions: Optional[int]` field has been added to the `DashScopeEmbeddings` model.
2.  **Model Support Validation**: A `model_validator` has been implemented to ensure that the `dimensions` parameter is only used with supported models (`text-embedding-v3` and `text-embedding-v4`), raising a `ValueError` for incompatible models. This provides clear, immediate feedback to the user without hardcoding dimension values.
3.  **API Integration**: The `embed_with_retry` function has been updated to pass the `dimension` parameter to the DashScope API call if it is provided.
4.  **Updated Defaults**: The default model has been changed to `text-embedding-v4` to reflect the latest recommended version.
5.  **Enhanced Documentation**: The class docstring has been updated to include a clear example of how to use the new `dimensions` parameter and to list the specific dimension options available for each supported model.

**Example Usage:**

```python
from langchain_community.embeddings import DashScopeEmbeddings

embeddings = DashScopeEmbeddings(
    model="text-embedding-v4",
    dimensions=256,  # Specify desired dimension
)

query_result = embeddings.embed_query("This is a test.")
```