### PR TITLE
fix: ensure 'integration' parameter is set for langchain in FireCrawlLoader

### DIFF
--- a/libs/community/langchain_community/document_loaders/firecrawl.py
+++ b/libs/community/langchain_community/document_loaders/firecrawl.py
@@ -267,7 +267,6 @@ class FireCrawlLoader(BaseLoader):
         self.url = url
         self.mode = mode
         self.params = params or {}
-        self.params['integration'] = 'langchain'
 
     def lazy_load(self) -> Iterator[Document]:
         self.params['integration'] = 'langchain'

--- a/libs/community/langchain_community/document_loaders/firecrawl.py
+++ b/libs/community/langchain_community/document_loaders/firecrawl.py
@@ -267,8 +267,10 @@ class FireCrawlLoader(BaseLoader):
         self.url = url
         self.mode = mode
         self.params = params or {}
+        self.params['integration'] = 'langchain'
 
     def lazy_load(self) -> Iterator[Document]:
+        self.params['integration'] = 'langchain'
         if self.mode == "scrape":
             firecrawl_docs = [
                 self.firecrawl.scrape_url(


### PR DESCRIPTION
Hello,

As maintainers of the Firecrawl project, we’re introducing a new parameter to help identify the origin of incoming requests. This PR adds support for that parameter, allowing us to track when someone is using our integration via `langchain`. 