### PR TITLE
WriteFileTool should create not existent parent dirs in file_path

### DIFF
--- a/libs/community/langchain_community/tools/file_management/write.py
+++ b/libs/community/langchain_community/tools/file_management/write.py
@@ -40,7 +40,7 @@ class WriteFileTool(BaseFileToolMixin, BaseTool):
         except FileValidationError:
             return INVALID_PATH_TEMPLATE.format(arg_name="file_path", value=file_path)
         try:
-            write_path.parent.mkdir(exist_ok=True, parents=False)
+            write_path.parent.mkdir(exist_ok=True, parents=True)
             mode = "a" if append else "w"
             with write_path.open(mode, encoding="utf-8") as f:
                 f.write(text)

--- a/libs/community/tests/unit_tests/tools/file_management/test_write.py
+++ b/libs/community/tests/unit_tests/tools/file_management/test_write.py
@@ -36,3 +36,11 @@ def test_write_file() -> None:
         tool.run({"file_path": file_path, "text": "Hello, world!"})
         assert (Path(temp_dir) / "file.txt").exists()
         assert (Path(temp_dir) / "file.txt").read_text() == "Hello, world!"
+
+
+def test_write_file_in_subdir_of_root_dir() -> None:
+    """Test the WriteFile tool when a a file path contains multiple directories to create."""
+    with TemporaryDirectory() as temp_dir:
+        tool = WriteFileTool(root_dir=temp_dir)
+        tool.run({"file_path": "a/b/file.txt", "text": "Hello, world!"})
+        assert (Path(temp_dir) / "a/b/file.txt").exists()


### PR DESCRIPTION
This PR updates the WriteFileTool to ensure that all missing parent directories are created when writing a file.
The current tool creates only one immediate parent directory. This causes failures in my workflow because I expect my agents to create many files in many dirs.