### PR TITLE
Fix FireCrawl API v1 compatibility and map mode handling

### DIFF
--- a/libs/community/langchain_community/document_loaders/firecrawl.py
+++ b/libs/community/langchain_community/document_loaders/firecrawl.py
@@ -174,7 +174,7 @@ class FireCrawlLoader(BaseLoader):
         self.params = params or {}
 
     def lazy_load(self) -> Iterator[Document]:
-        self.params['integration'] = 'langchain'
+        self.params["integration"] = "langchain"
         if self.mode == "scrape":
             firecrawl_docs = [
                 self.firecrawl.scrape_url(

--- a/libs/community/langchain_community/document_loaders/firecrawl.py
+++ b/libs/community/langchain_community/document_loaders/firecrawl.py
@@ -190,7 +190,9 @@ class FireCrawlLoader(BaseLoader):
         elif self.mode == "map":
             if not self.url:
                 raise ValueError("URL is required for map mode")
-            firecrawl_docs = self.firecrawl.map_url(self.url, **self.params)
+            map_response = self.firecrawl.map_url(self.url, **self.params)
+            # Map returns a MapResponse object with links attribute
+            firecrawl_docs = getattr(map_response, "links", [])
         elif self.mode == "extract":
             if not self.url:
                 raise ValueError("URL is required for extract mode")

--- a/libs/community/langchain_community/document_loaders/firecrawl.py
+++ b/libs/community/langchain_community/document_loaders/firecrawl.py
@@ -196,9 +196,13 @@ class FireCrawlLoader(BaseLoader):
                 raise ValueError("URL is required for extract mode")
             firecrawl_docs = [str(self.firecrawl.extract([self.url], **self.params))]
         elif self.mode == "search":
+            search_params = self.params.copy()
+            query = search_params.pop("query", None)
+            if not query:
+                raise ValueError("Query parameter is required for search mode")
             firecrawl_docs = self.firecrawl.search(
-                query=self.params.get("query"),
-                **self.params,
+                query=query,
+                **search_params,
             )
         else:
             raise ValueError(

--- a/libs/community/tests/unit_tests/document_loaders/test_firecrawl.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_firecrawl.py
@@ -1,11 +1,10 @@
 """Test FireCrawlLoader."""
 
 import sys
-from typing import Generator, List, Tuple
+from typing import Generator, Tuple
 from unittest.mock import MagicMock
 
 import pytest
-from langchain_core.documents import Document
 
 from langchain_community.document_loaders import FireCrawlLoader
 
@@ -45,7 +44,7 @@ class TestFireCrawlLoader:
 
     def test_load_extract_mode(
         self, mock_firecrawl: Tuple[MagicMock, MagicMock]
-    ) -> List[Document]:
+    ) -> None:
         """Test loading in extract mode."""
         # fixture에서 모킹된 객체 가져오기
         _, mock_client = mock_firecrawl
@@ -88,13 +87,50 @@ class TestFireCrawlLoader:
         assert isinstance(docs[0].page_content, str)
 
         # extract 메서드가 올바른 인자로 호출되었는지 확인
-        mock_client.extract.assert_called_once_with(
-            ["https://example.com"], params=params
-        )
+        mock_client.extract.assert_called_once_with(["https://example.com"], **params)
 
         # 응답이 문자열로 변환되었으므로 각 속성이 문자열에 포함되어 있는지 확인
         assert "extracted title" in docs[0].page_content
         assert "extracted main contents" in docs[0].page_content
         assert "success" in docs[0].page_content
 
-        return docs
+    def test_new_scrape_response_format(
+        self, mock_firecrawl: Tuple[MagicMock, MagicMock]
+    ) -> None:
+        """Test new ScrapeResponse object format handling."""
+        _, mock_client = mock_firecrawl
+
+        # Test 1: Object format (new ScrapeResponse-like)
+        mock_scrape_response = MagicMock()
+        mock_scrape_response.markdown = "New object content"
+        mock_scrape_response.html = None
+        mock_scrape_response.rawHtml = None
+        mock_scrape_response.metadata = {"source": "object_format"}
+
+        mock_client.scrape_url.return_value = mock_scrape_response
+
+        loader = FireCrawlLoader(
+            url="https://example.com", api_key="fake-key", mode="scrape"
+        )
+        docs = list(loader.lazy_load())
+
+        assert len(docs) == 1
+        assert "New object content" in docs[0].page_content
+        assert docs[0].metadata["source"] == "object_format"
+
+        # Test 2: Crawl mode with multiple docs
+        mock_client.crawl_url.return_value = {
+            "data": [
+                mock_scrape_response,
+                mock_scrape_response,
+            ]
+        }
+
+        loader_multi = FireCrawlLoader(
+            url="https://example.com", api_key="fake-key", mode="crawl"
+        )
+        docs = list(loader_multi.lazy_load())
+
+        assert len(docs) == 2
+        assert all("New object content" in doc.page_content for doc in docs)
+        assert all(doc.metadata["source"] == "object_format" for doc in docs)

--- a/libs/community/tests/unit_tests/document_loaders/test_firecrawl.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_firecrawl.py
@@ -94,7 +94,7 @@ class TestFireCrawlLoader:
         assert "extracted main contents" in docs[0].page_content
         assert "success" in docs[0].page_content
 
-    def test_new_scrape_response_format(
+    def test_handles_scrape_response_object_and_dict_formats(
         self, mock_firecrawl: Tuple[MagicMock, MagicMock]
     ) -> None:
         """Test new ScrapeResponse object format handling."""
@@ -134,3 +134,43 @@ class TestFireCrawlLoader:
         assert len(docs) == 2
         assert all("New object content" in doc.page_content for doc in docs)
         assert all(doc.metadata["source"] == "object_format" for doc in docs)
+
+    def test_search_mode_requires_query(
+        self, mock_firecrawl: Tuple[MagicMock, MagicMock]
+    ) -> None:
+        """Test that search mode requires a query parameter."""
+        _, mock_client = mock_firecrawl
+
+        # Test missing query parameter
+        loader = FireCrawlLoader(
+            url="https://dummy.com",  # URL not used in search mode but still required
+            api_key="fake-key",
+            mode="search",
+            params={},
+        )
+
+        with pytest.raises(
+            ValueError, match="Query parameter is required for search mode"
+        ):
+            list(loader.lazy_load())
+
+        # Test with query parameter
+        mock_search_response = MagicMock()
+        mock_search_response.markdown = "Search result content"
+        mock_search_response.metadata = {"url": "https://found.com"}
+
+        mock_client.search.return_value = [mock_search_response]
+
+        loader_with_query = FireCrawlLoader(
+            url="https://dummy.com",  # URL not used in search mode but still required
+            api_key="fake-key",
+            mode="search",
+            params={"query": "test search", "limit": 10},
+        )
+        docs = list(loader_with_query.lazy_load())
+
+        assert len(docs) == 1
+        assert "Search result content" in docs[0].page_content
+
+        # Verify search was called correctly without duplicate query
+        mock_client.search.assert_called_once_with(query="test search", limit=10)

--- a/libs/community/tests/unit_tests/document_loaders/test_firecrawl.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_firecrawl.py
@@ -173,4 +173,6 @@ class TestFireCrawlLoader:
         assert "Search result content" in docs[0].page_content
 
         # Verify search was called correctly without duplicate query
-        mock_client.search.assert_called_once_with(query="test search", limit=10)
+        mock_client.search.assert_called_once_with(
+            query="test search", limit=10, integration="langchain"
+        )


### PR DESCRIPTION
This PR fixes the FireCrawl integration to work with their v1 API.

  The main issue (#25) was that the API was rejecting requests with "unrecognized_keys": ["params"] because we were passing
   parameters incorrectly. Fixed by changing from params=self.params to **self.params to properly unpack the parameters.

  While testing the fix, I also discovered and fixed two other bugs:
  - Search mode was passing the query parameter twice, which could cause issues
  - Map mode was completely broken - it was trying to iterate over a MapResponse object instead of extracting the links
  attribute

  All modes (scrape, search, map, extract) are now working correctly with the v1 API. Added tests to cover these scenarios.

  Tested live with an actual FireCrawl API key to make sure everything works.

  Fixes #25