### PR TITLE
community[patch]: verify ssl by default in RecursiveUrlLoader

### DIFF
--- a/libs/community/langchain_community/document_loaders/recursive_url_loader.py
+++ b/libs/community/langchain_community/document_loaders/recursive_url_loader.py
@@ -80,7 +80,7 @@ class RecursiveUrlLoader(BaseLoader):
         GET request to an endpoint on Bob's site. Both sites are hosted on the
         same host, so such a request would not be prevented by default.
 
-        (See `LangChain Security Policy <https://python.langchain.com/docs/security/>`__)
+        See https://python.langchain.com/docs/security/
 
     Setup:
 


### PR DESCRIPTION
Change to a safer default