### PR TITLE
fix: Change JSON loader to be able to handle UTF-8-BOM files

### DIFF
--- a/libs/community/langchain_community/document_loaders/json_loader.py
+++ b/libs/community/langchain_community/document_loaders/json_loader.py
@@ -136,7 +136,7 @@ class JSONLoader(BaseLoader):
         """Load and return documents from the JSON file."""
         index = 0
         if self._json_lines:
-            with self.file_path.open(encoding="utf-8") as f:
+            with self.file_path.open(encoding="utf-8-sig") as f:
                 for line in f:
                     line = line.strip()
                     if line:
@@ -144,7 +144,7 @@ class JSONLoader(BaseLoader):
                             yield doc
                             index += 1
         else:
-            for doc in self._parse(self.file_path.read_text(encoding="utf-8"), index):
+            for doc in self._parse(self.file_path.read_text(encoding="utf-8-sig"), index):
                 yield doc
                 index += 1
 

--- a/libs/community/langchain_community/document_loaders/json_loader.py
+++ b/libs/community/langchain_community/document_loaders/json_loader.py
@@ -144,7 +144,9 @@ class JSONLoader(BaseLoader):
                             yield doc
                             index += 1
         else:
-            for doc in self._parse(self.file_path.read_text(encoding="utf-8-sig"), index):
+            for doc in self._parse(
+                self.file_path.read_text(encoding="utf-8-sig"), index
+            ):
                 yield doc
                 index += 1
 


### PR DESCRIPTION
Current parser will fail to ingest files that were encoded with the BOM bytes at the start. This is common for Windows-saved files and has been an issue for datasets where I can't ensure the default Unix encoding of UTF-8.

As far as I'm aware, decoding using utf-8-sig has no downsides when used on basic UTF-8 beyond small per-file processing overhead to check for the 3 bytes at the start, but it enables the code to correctly open files that have the BOM prefix.