### PR TITLE
:zap: fix: update OpenAI model cost values for accuracy

### DIFF
--- a/libs/community/langchain_community/callbacks/openai_info.py
+++ b/libs/community/langchain_community/callbacks/openai_info.py
@@ -57,13 +57,13 @@ MODEL_COST_PER_1K_TOKENS = {
     "o1-pro-completion": 0.6,
     "o1-pro-2025-03-19-completion": 0.6,
     # OpenAI o3 input
-    "o3": 0.01,
-    "o3-2025-04-16": 0.01,
-    "o3-cached": 0.0025,
-    "o3-2025-04-16-cached": 0.0025,
+    "o3": 0.002,
+    "o3-2025-04-16": 0.002,
+    "o3-cached": 0.0005,
+    "o3-2025-04-16-cached": 0.0005,
     # OpenAI o3 output
-    "o3-completion": 0.04,
-    "o3-2025-04-16-completion": 0.04,
+    "o3-completion": 0.008,
+    "o3-2025-04-16-completion": 0.008,
     # OpenAI o4-mini input
     "o4-mini": 0.0011,
     "o4-mini-2025-04-16": 0.0011,


### PR DESCRIPTION
# Motivation
See https://github.com/langchain-ai/langchain-community/issues/141

# Description
o3 prices were reduced by 5 several weeks ago and this has not been reflected in the package.
We have simply changed the prices in the constants.
https://platform.openai.com/docs/models/o3

- Input price is 2$ / 1M tokens
- Cached price is 0.50$ / 1M tokens
- Output price is 8$ / 1M tokens