### PR TITLE
fix: fix image buffer handling in parsers pdf.py

### DIFF
--- a/libs/community/langchain_community/document_loaders/parsers/pdf.py
+++ b/libs/community/langchain_community/document_loaders/parsers/pdf.py
@@ -457,11 +457,10 @@ class PyPDFParser(BaseBlobParser):
                     logger.warning("Unknown PDF Filter!")
                 if np_image is not None:
                     image_bytes = io.BytesIO()
-
+                    Image.fromarray(np_image).save(image_bytes, format="PNG")
                     if image_bytes.getbuffer().nbytes == 0:
                         continue
 
-                    Image.fromarray(np_image).save(image_bytes, format="PNG")
                     blob = Blob.from_data(image_bytes.getvalue(), mime_type="image/png")
                     image_text = next(self.images_parser.lazy_parse(blob)).page_content
                     images.append(
@@ -1112,10 +1111,9 @@ class PyMuPDFParser(BaseBlobParser):
                     pix.height, pix.width, -1
                 )
                 image_bytes = io.BytesIO()
+                numpy.save(image_bytes, image)
                 if image_bytes.getbuffer().nbytes == 0:
                     continue
-
-                numpy.save(image_bytes, image)
                 blob = Blob.from_data(
                     image_bytes.getvalue(), mime_type="application/x-npy"
                 )


### PR DESCRIPTION
The logic is incorrect, the image is always skipped as it's always regarded as zero
