### PR TITLE
Fix: Add default factory to api_wrapper of GoogleSerperRun

### DIFF
--- a/libs/community/langchain_community/tools/google_serper/tool.py
+++ b/libs/community/langchain_community/tools/google_serper/tool.py
@@ -21,7 +21,7 @@ class GoogleSerperRun(BaseTool):
         "Useful for when you need to answer questions about current events."
         "Input should be a search query."
     )
-    api_wrapper: GoogleSerperAPIWrapper
+    api_wrapper: GoogleSerperAPIWrapper = Field(default_factory=GoogleSerperAPIWrapper)
 
     def _run(
         self,


### PR DESCRIPTION
Add default factory to api_wrapper argument of GoogleSerperRun (to be the same as GoogleSerperResults)