### PR TITLE
feat: add Ollama Rerank integration

### DIFF
--- a/libs/community/langchain_community/document_compressors/__init__.py
+++ b/libs/community/langchain_community/document_compressors/__init__.py
@@ -26,6 +26,9 @@ if TYPE_CHECKING:
     from langchain_community.document_compressors.volcengine_rerank import (
         VolcengineRerank,
     )
+    from langchain_community.document_compressors.ollama_rerank import (
+        OllamaRerank,
+    )
 
 _module_lookup = {
     "LLMLinguaCompressor": "langchain_community.document_compressors.llmlingua_filter",
@@ -36,6 +39,7 @@ _module_lookup = {
     "DashScopeRerank": "langchain_community.document_compressors.dashscope_rerank",
     "VolcengineRerank": "langchain_community.document_compressors.volcengine_rerank",
     "InfinityRerank": "langchain_community.document_compressors.infinity_rerank",
+    "OllamaRerank": "langchain_community.document_compressors.ollama_rerank",
 }
 
 
@@ -55,4 +59,5 @@ __all__ = [
     "DashScopeRerank",
     "VolcengineRerank",
     "InfinityRerank",
+    "OllamaRerank",
 ]

--- a/libs/community/langchain_community/document_compressors/ollama_rerank.py
+++ b/libs/community/langchain_community/document_compressors/ollama_rerank.py
@@ -1,0 +1,167 @@
+from copy import deepcopy
+from typing import Self
+from typing import TYPE_CHECKING, Optional, Sequence
+
+from langchain_core.callbacks.base import Callbacks
+from langchain_core.documents import BaseDocumentCompressor, Document
+from pydantic import model_validator
+
+from langchain_community.vectorstores.pgvector import BaseModel
+
+if TYPE_CHECKING:
+    from ollama import Client, AsyncClient
+else:
+    try:
+        from ollama import Client, AsyncClient
+    except ImportError:
+        pass
+
+
+class RerankRequest(BaseModel):
+    model: str
+    query: str
+    top_n: int
+    documents: list[str]
+    return_documents: bool = False
+
+
+class RerankResponseResult(BaseModel):
+    index: int
+    relevance_score: float
+
+
+class RerankResponse(BaseModel):
+    model: str
+    results: list[RerankResponseResult]
+
+
+class OllamaRerank(BaseDocumentCompressor):
+    """Document compressor that uses `Ollama Rerank API`."""
+
+    model: str
+    """Model name to use."""
+
+    base_url: Optional[str] = None
+    """Base url the model is hosted under."""
+
+    client_kwargs: Optional[dict] = {}
+    """Additional kwargs to pass to the httpx clients. 
+    These arguments are passed to both synchronous and async clients.
+    Use sync_client_kwargs and async_client_kwargs to pass different arguments
+    to synchronous and asynchronous clients.
+    """
+
+    async_client_kwargs: Optional[dict] = {}
+    """Additional kwargs to merge with client_kwargs before
+    passing to the httpx AsyncClient.
+    For a full list of the params, see [this link](https://www.python-httpx.org/api/#asyncclient)
+    """
+
+    sync_client_kwargs: Optional[dict] = {}
+    """Additional kwargs to merge with client_kwargs before
+    passing to the httpx Client.
+    For a full list of the params, see [this link](https://www.python-httpx.org/api/#client)
+    """
+
+    _client: Client = PrivateAttr(default=None)  # type: ignore
+    """
+    The client to use for making requests.
+    """
+
+    _async_client: AsyncClient = PrivateAttr(default=None)  # type: ignore
+    """
+    The async client to use for making requests.
+    """
+
+    top_n: Optional[int] = 3
+    """Number of documents to return."""
+
+    @model_validator(mode="after")
+    def _set_clients(self) -> Self:
+        """Set clients to use for ollama."""
+        client_kwargs = self.client_kwargs or {}
+
+        sync_client_kwargs = client_kwargs
+        if self.sync_client_kwargs:
+            sync_client_kwargs = {**sync_client_kwargs, **self.sync_client_kwargs}
+
+        async_client_kwargs = client_kwargs
+        if self.async_client_kwargs:
+            async_client_kwargs = {**async_client_kwargs, **self.async_client_kwargs}
+
+        self._client = Client(host=self.base_url, **sync_client_kwargs)
+        self._async_client = AsyncClient(host=self.base_url, **async_client_kwargs)
+        return self
+
+    def compress_documents(
+            self,
+            documents: Sequence[Document],
+            query: str,
+            callbacks: Optional[Callbacks] = None,
+    ) -> Sequence[Document]:
+        """
+        Compress documents using Ollama's rerank API.
+        Args:
+            documents: A sequence of documents to compress.
+            query: The query to use for compressing the documents.
+            callbacks: Callbacks to run during the compression process.
+
+        Returns:
+            A sequence of compressed documents.
+        """
+        res = self._client._request(
+            RerankResponse,
+            'POST',
+            "/api/rerank",
+            json=RerankRequest(
+                model=self.model,
+                query=query,
+                top_n=self.top_n,
+                documents=[doc.page_content for doc in documents],
+                return_documents=True,
+            ).model_dump(),
+        )
+        compressed = []
+        for result in res.results:
+            doc = documents[result.index]
+            doc_copy = Document(doc.page_content, metadata=deepcopy(doc.metadata))
+            doc_copy.metadata["relevance_score"] = result.relevance_score
+            compressed.append(doc_copy)
+        return compressed
+
+    async def acompress_documents(
+            self,
+            documents: Sequence[Document],
+            query: str,
+            callbacks: Optional[Callbacks] = None,
+    ) -> Sequence[Document]:
+        """
+        Asynchronously compress documents using Ollama's rerank API.
+
+        Args:
+            documents: A sequence of documents to compress.
+            query: The query to use for compressing the documents.
+            callbacks: Callbacks to run during the compression process.
+
+        Returns:
+            A sequence of compressed documents.
+        """
+        res = await self._async_client._request(
+            RerankResponse,
+            'POST',
+            "/api/rerank",
+            json=RerankRequest(
+                model=self.model,
+                query=query,
+                top_n=self.top_n,
+                documents=[doc.page_content for doc in documents],
+                return_documents=True,
+            ).model_dump(),
+        )
+        compressed = []
+        for result in res.results:
+            doc = documents[result.index]
+            doc_copy = Document(doc.page_content, metadata=deepcopy(doc.metadata))
+            doc_copy.metadata["relevance_score"] = result.relevance_score
+            compressed.append(doc_copy)
+        return compressed

--- a/libs/community/pyproject.toml
+++ b/libs/community/pyproject.toml
@@ -61,7 +61,7 @@ lint = [
     "cffi<1.17.1; python_version < \"3.10\"",
     "cffi; python_version >= \"3.10\"",
 ]
-dev = ["jupyter<2.0.0,>=1.0.0", "setuptools<68.0.0,>=67.6.1", "langchain-core"]
+dev = ["jupyter<2.0.0,>=1.0.0", "setuptools<68.0.0,>=67.6.1", "langchain-core", "ollama<1.0.0,>=0.4.8"]
 typing = [
     "mypy<2.0,>=1.15",
     "types-pyyaml<7.0.0.0,>=6.0.12.2",

--- a/libs/community/tests/unit_tests/document_compressors/test_imports.py
+++ b/libs/community/tests/unit_tests/document_compressors/test_imports.py
@@ -9,6 +9,7 @@ EXPECTED_ALL = [
     "DashScopeRerank",
     "VolcengineRerank",
     "InfinityRerank",
+    "OllamaRerank",
 ]
 
 


### PR DESCRIPTION
# Description
This PR adds integration with Ollama's Rerank API through the new `OllamaRerank` document compressor.

> **Note**: Ollama's rerank feature is currently in [PR state](https://github.com/ollama/ollama/pull/11328) and not yet released.

## Key Features
- Reranks documents based on query relevance
- Adds relevance scores to document metadata

## Example Usage
```python
from langchain_community.document_compressors import OllamaRerank

reranker = OllamaRerank(
    model="dengcao/Qwen3-Embedding-0.6B:F16",
    top_n=3
)

compressed_docs = reranker.compress_documents(
    documents=docs,
    query="What is LangChain?"
)
```