### PR TITLE
fix: Use dollar-quoted literals for JSON parameters in Snowflake Cortex SQL

### DIFF
--- a/libs/community/langchain_community/chat_models/snowflake.py
+++ b/libs/community/langchain_community/chat_models/snowflake.py
@@ -277,8 +277,8 @@ class ChatSnowflakeCortex(BaseChatModel):
         sql_stmt = f"""
             select snowflake.cortex.{self.cortex_function}(
                 '{self.model}',
-                parse_json('{message_json}'),
-                parse_json('{options_json}')
+                parse_json($${message_json}$$),
+                parse_json($${options_json}$$)
             ) as llm_response;
         """
 


### PR DESCRIPTION
## Summary
Updates the SQL statement in ChatSnowflakeCortex to use Snowflake's dollar-quoted string literals (`$$`) instead of single quotes for JSON parameters. This prevents potential escaping issues when JSON contains single quotes or other special characters.

## Why
Using dollar-quoted literals is the recommended approach in Snowflake for JSON strings as it:
- Eliminates the need to escape single quotes within JSON
- Reduces the risk of SQL injection vulnerabilities
- Improves readability and maintainability
- Follows Snowflake best practices for handling JSON data