### PR TITLE
docs: remove double period in QuerySQLDatabaseTool description

### DIFF
--- a/libs/community/langchain_community/tools/sql_database/tool.py
+++ b/libs/community/langchain_community/tools/sql_database/tool.py
@@ -44,7 +44,7 @@ class QuerySQLDatabaseTool(BaseSQLDatabaseTool, BaseTool):
 
     name: str = "sql_db_query"
     description: str = """
-    Execute a SQL query against the database and get back the result..
+    Execute a SQL query against the database and get back the result.
     If the query is not correct, an error message will be returned.
     If an error is returned, rewrite the query, check the query, and try again.
     """


### PR DESCRIPTION
This removes a typo (two periods instead of one) from QuerySQLDatabaseTool description.