### PR TITLE
fix(youtube): replace deprecated YouTubeTranscriptApi.list_transcript…

### DIFF
--- a/libs/community/langchain_community/document_loaders/youtube.py
+++ b/libs/community/langchain_community/document_loaders/youtube.py
@@ -259,7 +259,7 @@ class YoutubeLoader(BaseLoader):
             self._metadata.update(video_info)
 
         try:
-            transcript_list = YouTubeTranscriptApi.list_transcripts(self.video_id)
+            transcript_list = YouTubeTranscriptApi.list(self.video_id)
         except TranscriptsDisabled:
             return []
 
@@ -412,7 +412,7 @@ class GoogleApiYoutubeLoader(BaseLoader):
     def _get_transcripe_for_video_id(self, video_id: str) -> str:
         from youtube_transcript_api import NoTranscriptFound, YouTubeTranscriptApi
 
-        transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+        transcript_list = YouTubeTranscriptApi.list(video_id)
         try:
             transcript = transcript_list.find_transcript([self.captions_language])
         except NoTranscriptFound:
@@ -525,3 +525,4 @@ class GoogleApiYoutubeLoader(BaseLoader):
         else:
             raise ValueError("Must specify either channel_name or video_ids")
         return document_list
+    


### PR DESCRIPTION
## 🔧 Pull Request: Fix YouTubeTranscriptApi Deprecation by Replacing `list_transcripts()` with `list()`

### Summary

This PR updates the `YoutubeLoader` and `GoogleApiYoutubeLoader` classes in `langchain_community.document_loaders` to reflect recent changes in the `youtube-transcript-api` library.

Specifically, it replaces all usage of the now-deprecated method `YouTubeTranscriptApi.list_transcripts(video_id)` with the new method `YouTubeTranscriptApi.list(video_id)` introduced in the latest release of the upstream package.

---

### ✅ What's Changed

- **Fixed**: Updated `YoutubeLoader.load()` to use `YouTubeTranscriptApi.list(video_id)`
- **Fixed**: Updated `GoogleApiYoutubeLoader._get_transcripe_for_video_id()` to use `YouTubeTranscriptApi.list(video_id)`
- **Maintained**: Backward-compatible structure — no public API breakages
- **Validated**: Ensured fallback, language, and translation behavior remained consistent

---

### 📌 Motivation

Recent versions of [`youtube-transcript-api`](https://github.com/jdepoix/youtube-transcript-api) deprecated the `list_transcripts()` method. This causes a runtime `AttributeError` in any downstream projects (including LangChain) using that method. (I noticed this because I current use this API in my project)

### 🔄 Compatibility

- ✅ Compatible with the latest `youtube-transcript-api`
- ✅ No breaking changes to existing loader interfaces
- ✅ All other logic and API usage retained

---

### 🙏 Acknowledgements

Thanks to the LangChain maintainers and the `youtube-transcript-api` contributors for making it easier to build robust integrations.