### PR TITLE
RSS Feed Document Loader Publish Date Fallback

### DIFF
--- a/libs/community/langchain_community/document_loaders/rss.py
+++ b/libs/community/langchain_community/document_loaders/rss.py
@@ -124,6 +124,11 @@ class RSSFeedLoader(BaseLoader):
                     )
                     article = loader.load()[0]
                     article.metadata["feed"] = url
+                    # If the publish date is not set by newspaper, try to extract it from the feed entry
+                    if article.metadata.get("publish_date") is None:
+                        from datetime import datetime
+                        publish_date = entry.get("published_parsed", None)
+                        article.metadata["publish_date"] = datetime(*publish_date[:6]) if publish_date else None
                     yield article
             except Exception as e:
                 if self.continue_on_failure:


### PR DESCRIPTION
As mentioned on issue https://github.com/langchain-ai/langchain/issues/12202 currently the publish_date on RSS document loader is unstable, depending on newspaper3k's parsing of that date on the article URL.

This PR creates a fallback on the loader to use the feed entry's publish date if newspaper3k doesn't return that in the article object.
