### PR TITLE
Fix YoutubeLoader by switching to `YouTubeTranscriptApi().list(...)` (resolves #204)

### DIFF
--- a/libs/community/langchain_community/document_loaders/youtube.py
+++ b/libs/community/langchain_community/document_loaders/youtube.py
@@ -412,7 +412,7 @@ class GoogleApiYoutubeLoader(BaseLoader):
     def _get_transcripe_for_video_id(self, video_id: str) -> str:
         from youtube_transcript_api import NoTranscriptFound, YouTubeTranscriptApi
 
-        transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+        transcript_list = YouTubeTranscriptApi().list(video_id)
         try:
             transcript = transcript_list.find_transcript([self.captions_language])
         except NoTranscriptFound:


### PR DESCRIPTION
## What

This PR resolves the issue reported in [langchain-community fixes #204] and many users facing  — **`AttributeError: type object 'YouTubeTranscriptApi' has no attribute 'list_transcripts'`** — by updating `YoutubeLoader` to instantiate `YouTubeTranscriptApi` and  calling `list`.

###  Background

The root cause is that in recent versions of `youtube_transcript_api`, the `list` method was converted from a `@classmethod` to an **instance method**. Calling it directly on the class now raises: 

 AttributeError: type object 'YouTubeTranscriptApi' has no attribute 'list_transcripts'
<img width="1571" height="223" alt="image" src="https://github.com/user-attachments/assets/36ce589e-701f-45d2-aa11-b8d59c99754a" />
###  Changes

- Updated `langchain-community\libs\community\langchain_community\document_loaders\youtube.py`:
  ```diff
  - transcript_list = YouTubeTranscriptApi.list_transcripts(self.video_id)
  + transcript_list = YouTubeTranscriptApi().list(self.video_id)

## Testing
I tested the fix locally using a public YouTube video; YoutubeLoader now works without errors

Test suite ran successfully via:

`pip install -e .
uv run test.py`

Output after fix : 
<img width="1637" height="438" alt="image" src="https://github.com/user-attachments/assets/93ed7f08-4719-485b-a463-798ab589c7d2" />

Thanks for maintaining such a great library—this fix should smooth over the roadblock some users hit when updating their dependencies.

❤️