### PR TITLE
Fill Document.id during a search in ElasticSearch VectorStore

### DIFF
--- a/libs/community/langchain_community/vectorstores/elasticsearch.py
+++ b/libs/community/langchain_community/vectorstores/elasticsearch.py
@@ -834,6 +834,7 @@ class ElasticsearchStore(VectorStore):
 
         def default_doc_builder(hit: Dict) -> Document:
             return Document(
+                id=hit["_id"],
                 page_content=hit["_source"].get(self.query_field, ""),
                 metadata=hit["_source"]["metadata"],
             )


### PR DESCRIPTION
When doing a search using the ElasticSearch VectorStore, the `Document.id` attribute is not being filled.