### PR TITLE
Deprecate to Oracle AI Vector Search classes

### DIFF
--- a/libs/community/langchain_community/document_loaders/oracleadb_loader.py
+++ b/libs/community/langchain_community/document_loaders/oracleadb_loader.py
@@ -1,10 +1,23 @@
 from typing import Any, Dict, List, Optional, Union
 
+from langchain_core._api import deprecated
 from langchain_core.documents import Document
 
 from langchain_community.document_loaders.base import BaseLoader
 
 
+@deprecated(
+    since="0.3.30",
+    removal="1.0",
+    message=(
+        "This class is deprecated and will be removed in a future release. "
+        "Instead, please use `OracleAutonomousDatabaseLoader` from the "
+        "`langchain-oracledb` package. "
+        "For more information, refer to <https://github.com/oracle/langchain-oracle/tree/main/libs/oracledb>."
+    ),
+    alternative="from langchain_oracledb.document_loaders import OracleAutonomousDatabaseLoader;",  # noqa: E501
+    pending=False,
+)
 class OracleAutonomousDatabaseLoader(BaseLoader):
     """
     Load from oracle adb

--- a/libs/community/langchain_community/document_loaders/oracleai.py
+++ b/libs/community/langchain_community/document_loaders/oracleai.py
@@ -19,6 +19,7 @@ import traceback
 from html.parser import HTMLParser
 from typing import TYPE_CHECKING, Any, Dict, List, Optional, Tuple, Union
 
+from langchain_core._api import deprecated
 from langchain_core.document_loaders import BaseLoader
 from langchain_core.documents import Document
 from langchain_text_splitters import TextSplitter
@@ -181,6 +182,18 @@ class OracleDocReader:
 """OracleDocLoader class"""
 
 
+@deprecated(
+    since="0.3.30",
+    removal="1.0",
+    message=(
+        "This class is deprecated and will be removed in a future release. "
+        "Instead, please use `OracleDocLoader` from the "
+        "`langchain-oracledb` package. "
+        "package. For more information, refer to <https://github.com/oracle/langchain-oracle/tree/main/libs/oracledb>."
+    ),
+    alternative="from langchain_oracledb.document_loaders import OracleDocLoader;",
+    pending=False,
+)
 class OracleDocLoader(BaseLoader):
     """Read documents using OracleDocLoader
     Args:
@@ -377,6 +390,18 @@ class OracleDocLoader(BaseLoader):
             raise
 
 
+@deprecated(
+    since="0.3.30",
+    removal="1.0",
+    message=(
+        "This class is deprecated and will be removed in a future release. "
+        "Instead, please use `OracleTextSplitter` from the "
+        "`langchain-oracledb` package. "
+        "For more information, refer to <https://github.com/oracle/langchain-oracle/tree/main/libs/oracledb>."
+    ),
+    alternative="from langchain_oracledb.document_loaders import OracleTextSplitter;",
+    pending=False,
+)
 class OracleTextSplitter(TextSplitter):
     """Splitting text using Oracle chunker."""
 

--- a/libs/community/langchain_community/embeddings/oracleai.py
+++ b/libs/community/langchain_community/embeddings/oracleai.py
@@ -13,6 +13,7 @@ import logging
 import traceback
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from langchain_core._api import deprecated
 from langchain_core.embeddings import Embeddings
 from pydantic import BaseModel, ConfigDict
 
@@ -24,6 +25,18 @@ logger = logging.getLogger(__name__)
 """OracleEmbeddings class"""
 
 
+@deprecated(
+    since="0.3.30",
+    removal="1.0",
+    message=(
+        "This class is deprecated and will be removed in a future release. "
+        "Instead, please use `OracleEmbeddings` from the "
+        "`langchain-oracledb` package. "
+        "For more information, refer to <https://github.com/oracle/langchain-oracle/tree/main/libs/oracledb>."
+    ),
+    alternative="from langchain_oracledb.embeddings import OracleEmbeddings;",
+    pending=False,
+)
 class OracleEmbeddings(BaseModel, Embeddings):
     """Get Embeddings"""
 

--- a/libs/community/langchain_community/utilities/oracleai.py
+++ b/libs/community/langchain_community/utilities/oracleai.py
@@ -13,6 +13,7 @@ import logging
 import traceback
 from typing import TYPE_CHECKING, Any, Dict, List, Optional
 
+from langchain_core._api import deprecated
 from langchain_core.documents import Document
 
 if TYPE_CHECKING:
@@ -23,6 +24,18 @@ logger = logging.getLogger(__name__)
 """OracleSummary class"""
 
 
+@deprecated(
+    since="0.3.30",
+    removal="1.0",
+    message=(
+        "This class is deprecated and will be removed in a future release. "
+        "Instead, please use `OracleSummary` from the "
+        "`langchain-oracledb` package. "
+        "For more information, refer to <https://github.com/oracle/langchain-oracle/tree/main/libs/oracledb>."
+    ),
+    alternative="from langchain_oracledb.utilities import OracleSummary;",
+    pending=False,
+)
 class OracleSummary:
     """Get Summary
     Args:

--- a/libs/community/langchain_community/vectorstores/oraclevs.py
+++ b/libs/community/langchain_community/vectorstores/oraclevs.py
@@ -28,6 +28,7 @@ if TYPE_CHECKING:
     from oracledb import Connection
 
 import numpy as np
+from langchain_core._api import deprecated
 from langchain_core.documents import Document
 from langchain_core.embeddings import Embeddings
 from langchain_core.vectorstores import VectorStore
@@ -435,6 +436,18 @@ def drop_index_if_exists(client: Any, index_name: str) -> None:
     return
 
 
+@deprecated(
+    since="0.3.30",
+    removal="1.0",
+    message=(
+        "This class is deprecated and will be removed in a future release. "
+        "Instead, please use `OracleVS` from the "
+        "`langchain-oracledb` package. "
+        "For more information, refer to <https://github.com/oracle/langchain-oracle/tree/main/libs/oracledb>."
+    ),
+    alternative="from langchain_oracledb.vectorstores import OracleVS;",
+    pending=False,
+)
 class OracleVS(VectorStore):
     """`OracleVS` vector store.
 


### PR DESCRIPTION
`Oracle AI Vector Search` integrations for LangChain have been moved to a dedicated package, [langchain-oracledb ](https://pypi.org/project/langchain-oracledb/), and a new repository, [langchain-oracle ](https://github.com/oracle/langchain-oracle/tree/main/libs/oracledb). This PR updates the corresponding classes to include a deprecation notice.