### PR TITLE
fix(youtube): use YouTubeTranscriptApi().list() for v1+ compatibility

### DIFF
--- a/libs/community/langchain_community/document_loaders/youtube.py
+++ b/libs/community/langchain_community/document_loaders/youtube.py
@@ -259,7 +259,8 @@ class YoutubeLoader(BaseLoader):
             self._metadata.update(video_info)
 
         try:
-            transcript_list = YouTubeTranscriptApi.list_transcripts(self.video_id)
+            ytt_api = YouTubeTranscriptApi()
+            transcript_list = ytt_api.list(self.video_id)
         except TranscriptsDisabled:
             return []
 
@@ -412,7 +413,8 @@ class GoogleApiYoutubeLoader(BaseLoader):
     def _get_transcripe_for_video_id(self, video_id: str) -> str:
         from youtube_transcript_api import NoTranscriptFound, YouTubeTranscriptApi
 
-        transcript_list = YouTubeTranscriptApi.list_transcripts(video_id)
+        ytt_api = YouTubeTranscriptApi()
+        transcript_list = ytt_api.list(video_id)
         try:
             transcript = transcript_list.find_transcript([self.captions_language])
         except NoTranscriptFound:


### PR DESCRIPTION
### Summary
This fixes an AttributeError caused by `YouTubeTranscriptApi.list_transcripts()` being removed in recent versions of `youtube-transcript-api`. The loader now instantiates `YouTubeTranscriptApi()` and calls the instance method `.list(video_id)`.

### Problem
Reproduction:
```python
from langchain_community.document_loaders import YoutubeLoader
loader = YoutubeLoader.from_youtube_url("https://www.youtube.com/watch?v=QsYGlZkevEg", add_video_info=False)
loader.load()
# => AttributeError: type object 'YouTubeTranscriptApi' has no attribute 'list_transcripts'
