### PR TITLE
Fix broken link of partition docs of  package

### DIFF
--- a/libs/community/langchain_community/document_loaders/markdown.py
+++ b/libs/community/langchain_community/document_loaders/markdown.py
@@ -69,7 +69,7 @@ class UnstructuredMarkdownLoader(UnstructuredFileLoader):
 
     References
     ----------
-    https://unstructured-io.github.io/unstructured/core/partition.html#partition-md
+    https://docs.unstructured.io/open-source/core-functionality/partitioning#partition-md
     """  # noqa: E501
 
     def __init__(


### PR DESCRIPTION
Fix the broken link of partition documentation of unstructured package, since the docs url has been changed recently.