### PR TITLE
fix: fixed the regex in the presigned url check

### DIFF
--- a/libs/community/langchain_community/document_loaders/pdf.py
+++ b/libs/community/langchain_community/document_loaders/pdf.py
@@ -165,7 +165,7 @@ class BasePDFLoader(BaseLoader, ABC):
         """Check if the url is a presigned S3 url."""
         try:
             result = urlparse(url)
-            return bool(re.search(r"\.s3\.amazonaws\.com$", result.netloc))
+            return bool(re.search(r"\.s3(?:\.[\w-]+)?\.amazonaws\.com", result.netloc))
         except ValueError:
             return False
 


### PR DESCRIPTION
The regex used to determine whether a url is a presigned url did not capture the pattern of presigned urls in s3 buckets. as a result, presigned urls never passed this test and and OSError ("File name is too long") was returned.