### PR TITLE
Deprecated azure blob storage loaders

### DIFF
--- a/libs/community/langchain_community/document_loaders/azure_blob_storage_container.py
+++ b/libs/community/langchain_community/document_loaders/azure_blob_storage_container.py
@@ -12,7 +12,7 @@ from langchain_community.document_loaders.base import BaseLoader
 @deprecated(
     since="0.4",
     removal="1.0",
-    alternative_import="langchain_azure_storage.document_loaders",
+    alternative_import="langchain_azure_storage.document_loaders.AzureBlobStorageLoader",
 )
 class AzureBlobStorageContainerLoader(BaseLoader):
     """Load from `Azure Blob Storage` container."""

--- a/libs/community/langchain_community/document_loaders/azure_blob_storage_file.py
+++ b/libs/community/langchain_community/document_loaders/azure_blob_storage_file.py
@@ -12,7 +12,7 @@ from langchain_community.document_loaders.unstructured import UnstructuredFileLo
 @deprecated(
     since="0.4",
     removal="1.0",
-    alternative_import="langchain_azure_storage.document_loaders",
+    alternative_import="langchain_azure_storage.document_loaders.AzureBlobStorageLoader",
 )
 class AzureBlobStorageFileLoader(BaseLoader):
     """Load from `Azure Blob Storage` files."""


### PR DESCRIPTION
Added a deprecation warning for `AzureBlobStorageFileLoader` and `AzureBlobStorageContainerLoader` since a new [`langchain-azure-storage`](https://pypi.org/project/langchain-azure-storage/) package was released which contains the [`AzureBlobStorageLoader`](https://github.com/langchain-ai/langchain-azure/blob/main/libs/azure-storage/README.md).