### PR TITLE
feat: add fortran to language parsers

### DIFF
--- a/libs/community/langchain_community/document_loaders/parsers/language/fortran.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/fortran.py
@@ -1,0 +1,33 @@
+from typing import TYPE_CHECKING
+
+from langchain_community.document_loaders.parsers.language.tree_sitter_segmenter import (  # noqa: E501
+    TreeSitterSegmenter,
+)
+
+if TYPE_CHECKING:
+    from tree_sitter import Language
+
+
+CHUNK_QUERY = """
+    [
+        (subroutine) @subroutine
+        (function) @function
+        (program) @program
+        (module) @module
+    ]
+""".strip()
+
+
+class FortranSegmenter(TreeSitterSegmenter):
+    """Code segmenter for Fortran."""
+
+    def get_language(self) -> "Language":
+        from tree_sitter_languages import get_language
+
+        return get_language("fortran")
+
+    def get_chunk_query(self) -> str:
+        return CHUNK_QUERY
+
+    def make_line_comment(self, text: str) -> str:
+        return f"! {text}"

--- a/libs/community/langchain_community/document_loaders/parsers/language/language_parser.py
+++ b/libs/community/langchain_community/document_loaders/parsers/language/language_parser.py
@@ -11,6 +11,9 @@ from langchain_community.document_loaders.parsers.language.cobol import CobolSeg
 from langchain_community.document_loaders.parsers.language.cpp import CPPSegmenter
 from langchain_community.document_loaders.parsers.language.csharp import CSharpSegmenter
 from langchain_community.document_loaders.parsers.language.elixir import ElixirSegmenter
+from langchain_community.document_loaders.parsers.language.fortran import (
+    FortranSegmenter,
+)
 from langchain_community.document_loaders.parsers.language.go import GoSegmenter
 from langchain_community.document_loaders.parsers.language.java import JavaSegmenter
 from langchain_community.document_loaders.parsers.language.javascript import (
@@ -49,6 +52,12 @@ LANGUAGE_EXTENSIONS: Dict[str, str] = {
     "ex": "elixir",
     "exs": "elixir",
     "sql": "sql",
+    "f": "fortran",
+    "f90": "fortran",
+    "f95": "fortran",
+    "f03": "fortran",
+    "f08": "fortran",
+    "for": "fortran",
 }
 
 LANGUAGE_SEGMENTERS: Dict[str, Any] = {
@@ -70,6 +79,7 @@ LANGUAGE_SEGMENTERS: Dict[str, Any] = {
     "php": PHPSegmenter,
     "elixir": ElixirSegmenter,
     "sql": SQLSegmenter,
+    "fortran": FortranSegmenter,
 }
 
 Language = Literal[
@@ -97,6 +107,7 @@ Language = Literal[
     "perl",
     "elixir",
     "sql",
+    "fortran",
 ]
 
 
@@ -116,6 +127,7 @@ class LanguageParser(BaseBlobParser):
     - C#: "csharp" (*)
     - COBOL: "cobol"
     - Elixir: "elixir"
+    - Fortran: "fortran" (*)
     - Go: "go" (*)
     - Java: "java" (*)
     - JavaScript: "js" (requires package `esprima`)

--- a/libs/community/tests/unit_tests/document_loaders/parsers/language/test_fortran.py
+++ b/libs/community/tests/unit_tests/document_loaders/parsers/language/test_fortran.py
@@ -1,0 +1,80 @@
+import unittest
+
+import pytest
+
+from langchain_community.document_loaders.parsers.language.fortran import (
+    FortranSegmenter,
+)
+
+
+@pytest.mark.requires("tree_sitter", "tree_sitter_languages")
+class TestFortranSegmenter(unittest.TestCase):
+    def setUp(self) -> None:
+        self.example_code = """program hello
+    implicit none
+    write(*,*) 'Hello, World!'
+end program hello
+
+subroutine greet(name)
+    implicit none
+    character(len=*), intent(in) :: name
+    write(*,*) 'Hello, ', name
+end subroutine greet
+
+function add(a, b) result(c)
+    implicit none
+    integer, intent(in) :: a, b
+    integer :: c
+    c = a + b
+end function add
+
+module math_ops
+    implicit none
+contains
+    function multiply(x, y) result(z)
+        real :: x, y, z
+        z = x * y
+    end function multiply
+end module math_ops"""
+
+        self.expected_simplified_code = """! Code for: program hello
+! Code for: subroutine greet(name)
+! Code for: function add(a, b) result(c)
+! Code for: module math_ops"""
+
+        self.expected_extracted_code = [
+            (
+                "program hello\n    implicit none\n    write(*,*) "
+                "'Hello, World!'\nend program hello\n"
+            ),
+            (
+                "subroutine greet(name)\n    implicit none\n    "
+                "character(len=*), intent(in) :: name\n    write(*,*) "
+                "'Hello, ', name\nend subroutine greet\n"
+            ),
+            (
+                "function add(a, b) result(c)\n    implicit none\n    "
+                "integer, intent(in) :: a, b\n    integer :: c\n    "
+                "c = a + b\nend function add\n"
+            ),
+            (
+                "module math_ops\n    implicit none\ncontains\n    "
+                "function multiply(x, y) result(z)\n        real :: x, y, z\n"
+                "        z = x * y\n    end function multiply\n"
+                "end module math_ops"
+            ),
+        ]
+
+    def test_is_valid(self) -> None:
+        self.assertTrue(FortranSegmenter("program test\nend program test").is_valid())
+        self.assertFalse(FortranSegmenter("a b c 1 2 3").is_valid())
+
+    def test_extract_functions_classes(self) -> None:
+        segmenter = FortranSegmenter(self.example_code)
+        extracted_code = segmenter.extract_functions_classes()
+        self.assertEqual(extracted_code, self.expected_extracted_code)
+
+    def test_simplify_code(self) -> None:
+        segmenter = FortranSegmenter(self.example_code)
+        simplified_code = segmenter.simplify_code()
+        self.assertEqual(simplified_code, self.expected_simplified_code)


### PR DESCRIPTION
## Add Fortran Language Parser Support

### Summary
This PR adds Fortran language parsing support to LangChain's `LanguageParser`, enabling syntax-aware code splitting for Fortran source files.

### Changes
- Implements `FortranSegmenter` class for parsing Fortran code structure
- Adds Fortran (`'fortran'` or `'f90'`) to supported languages in `LanguageParser`
- Updates `LANGUAGE_EXTENSIONS` and `LANGUAGE_SEGMENTERS` mappings
- Enables extraction of top-level functions, subroutines, and modules into separate documents
- Supports common Fortran file extensions (`.f`, `.f90`, `.f95`, etc.)

### Usage
```python
from langchain_community.document_loaders.generic import GenericLoader
from langchain_community.document_loaders.parsers import LanguageParser

loader = GenericLoader.from_filesystem(
    "./fortran_code",
    glob="**/*",
    suffixes=[".f90"],
    parser=LanguageParser(language="fortran")
)
docs = loader.load()
```

### Testing
- [x] Added unit tests for Fortran parser
- [x] Verified parsing of functions, subroutines, and modules
- [x] Tested with various Fortran dialects (F77, F90, F95, F2003)