### PR TITLE
feat(vectorstores): add routing parameter support to hybrid search

### DIFF
--- a/libs/community/langchain_community/vectorstores/opensearch_vector_search.py
+++ b/libs/community/langchain_community/vectorstores/opensearch_vector_search.py
@@ -1302,9 +1302,15 @@ class OpenSearchVectorSearch(VectorStore):
                 # hybrid search without post filter
                 payload = _default_hybrid_search_query(query_text, embeded_query, k)
 
-            response = self.client.transport.perform_request(
-                method="GET", url=path, body=payload
-            )
+            request_args: Dict[str, Any] = {
+                "method": "GET",
+                "url": path,
+                "body": payload,
+            }
+            if self.routing:
+                request_args["params"] = {"routing": self.routing}
+
+            response = self.client.transport.perform_request(**request_args)
 
             return [hit for hit in response["hits"]["hits"]]
 


### PR DESCRIPTION
**Description:** Add routing parameter support to hybrid search in OpenSearchVectorSearch. Previously, the routing parameter was only supported in standard search operations but not in hybrid search. This change ensures consistency across all search methods by allowing routing to be passed as a query parameter when performing hybrid searches.

**Issue:** N/A

**Dependencies:** None

**Note:** None