### PR TITLE
feat(vectorstores): add routing support for hybrid search

### DIFF
--- a/libs/community/langchain_community/vectorstores/opensearch_vector_search.py
+++ b/libs/community/langchain_community/vectorstores/opensearch_vector_search.py
@@ -1302,9 +1302,15 @@ class OpenSearchVectorSearch(VectorStore):
                 # hybrid search without post filter
                 payload = _default_hybrid_search_query(query_text, embeded_query, k)
 
-            response = self.client.transport.perform_request(
-                method="GET", url=path, body=payload
-            )
+            request_args: Dict[str, Any] = {
+                "method": "GET",
+                "url": path,
+                "body": payload,
+            }
+            if self.routing:
+                request_args["params"] = {"routing": self.routing}
+
+            response = self.client.transport.perform_request(**request_args)
 
             return [hit for hit in response["hits"]["hits"]]
 


### PR DESCRIPTION
# feat(vectorstores): add routing support for hybrid search

## Summary

This PR adds routing parameter support for hybrid search (`HYBRID_SEARCH`) in the `similarity_search_with_score` method of the `OpenSearchVectorSearch` class.

## Changes

### Modified Files
- `libs/community/langchain_community/vectorstores/opensearch_vector_search.py`

### Change Details

Modified the hybrid search processing within the `similarity_search_with_score` method to add the `routing` parameter to the request parameters when `self.routing` is set.

**Before:**
```python
response = self.client.transport.perform_request(
    method="GET", url=path, body=payload
)
```

**After:**
```python
request_args: Dict[str, Any] = {
    "method": "GET",
    "url": path,
    "body": payload,
}
if self.routing:
    request_args["params"] = {"routing": self.routing}

response = self.client.transport.perform_request(**request_args)
```

## Background

OpenSearch's routing feature is used to route requests to specific shards, which helps optimize performance and improve data locality.

In the existing code, routing was already supported for `APPROXIMATE_SEARCH`, `SCRIPT_SCORING_SEARCH`, and `PAINLESS_SCRIPTING_SEARCH` search types (lines 1320-1322), but it was not supported for hybrid search (`HYBRID_SEARCH`).

This change ensures that routing functionality is consistently available across all search types.

## Compatibility

- **Backward Compatibility**: No impact on existing APIs. When the `routing` parameter is not set, the behavior remains unchanged.
- **Breaking Changes**: None