### PR TITLE
Fix: Supabase vectorstore 'SyncRPCFilterRequestBuilder' object has no attribute 'params'

### DIFF
--- a/libs/community/langchain_community/vectorstores/supabase.py
+++ b/libs/community/langchain_community/vectorstores/supabase.py
@@ -243,9 +243,7 @@ class SupabaseVectorStore(VectorStore):
         query_builder = self._client.rpc(self.query_name, match_documents_params)
 
         if postgrest_filter:
-            query_builder.params = query_builder.params.set(
-                "and", f"({postgrest_filter})"
-            )
+            query_builder = query_builder.filter("and", f"({postgrest_filter})")
 
         query_builder = query_builder.limit(k)
 
@@ -288,9 +286,7 @@ class SupabaseVectorStore(VectorStore):
         query_builder = self._client.rpc(self.query_name, match_documents_params)
 
         if postgrest_filter:
-            query_builder.params = query_builder.params.set(
-                "and", f"({postgrest_filter})"
-            )
+            query_builder = query_builder.filter("and", f"({postgrest_filter})")
 
         query_builder = query_builder.limit(k)
 


### PR DESCRIPTION
The functions `similarity_search_by_vector_with_relevance_scores` and
`similarity_search_by_vector_returning_embeddings` are currently using:

    query_builder.params.set("and", f"({postgrest_filter})")

Previously, I encountered an error when calling
`query_builder.params.set("limit", k)`, which was addressed in issue #377.

However, I found that using the `params` attribute at all may still cause
errors, since the latest Supabase Python client removes the `params` property
from `SyncRPCFilterRequestBuilder`.

To ensure compatibility with the updated SDK, I replaced the old `params.set(...)`
usage with the officially supported builder methods:

    query_builder = query_builder.filter("and", f"({postgrest_filter})")
    query_builder = query_builder.limit(k)

This change prevents AttributeError exceptions and aligns the implementation
with the current Supabase Python client API.