### PR TITLE
feat(docs): add mime_type parameter to AmazonTextractPDFLoader

### DIFF
--- a/libs/community/langchain_community/document_loaders/parsers/pdf.py
+++ b/libs/community/langchain_community/document_loaders/parsers/pdf.py
@@ -1542,6 +1542,7 @@ class AmazonTextractPDFParser(BaseBlobParser):
         client: Optional[Any] = None,
         *,
         linearization_config: Optional[TextLinearizationConfig] = None,
+        mime_type: Optional[str] = None,
     ) -> None:
         """Initializes the parser.
 
@@ -1553,6 +1554,7 @@ class AmazonTextractPDFParser(BaseBlobParser):
             linearization_config: Config to be used for linearization of the output
                                   should be an instance of TextLinearizationConfig from
                                   the `textractor` pkg
+            mime_type: Mime type of the document to be parsed.
         """
 
         try:
@@ -1561,6 +1563,7 @@ class AmazonTextractPDFParser(BaseBlobParser):
 
             self.tc = tc
             self.textractor = textractor
+            self.mime_type = mime_type
 
             if textract_features is not None:
                 self.textract_features = [
@@ -1617,6 +1620,7 @@ class AmazonTextractPDFParser(BaseBlobParser):
                 input_document=str(blob.path),
                 features=self.textract_features,
                 boto3_textract_client=self.boto3_textract_client,
+                mime_type=self.mime_type,
             )
         else:
             textract_response_json = self.tc.call_textract(
@@ -1624,6 +1628,7 @@ class AmazonTextractPDFParser(BaseBlobParser):
                 features=self.textract_features,
                 call_mode=self.tc.Textract_Call_Mode.FORCE_SYNC,
                 boto3_textract_client=self.boto3_textract_client,
+                mime_type=self.mime_type,
             )
 
         document = self.textractor.Document.open(textract_response_json)

--- a/libs/community/langchain_community/document_loaders/pdf.py
+++ b/libs/community/langchain_community/document_loaders/pdf.py
@@ -1079,6 +1079,7 @@ class AmazonTextractPDFLoader(BasePDFLoader):
         headers: Optional[dict] = None,
         *,
         linearization_config: Optional["TextLinearizationConfig"] = None,
+        mime_type: Optional[str] = None,
     ) -> None:
         """Initialize the loader.
 
@@ -1142,6 +1143,7 @@ class AmazonTextractPDFLoader(BasePDFLoader):
             textract_features=features,
             client=client,
             linearization_config=linearization_config,
+            mime_type=mime_type,
         )
 
     def load(self) -> list[Document]:
@@ -1380,7 +1382,7 @@ class ZeroxPDFLoader(BasePDFLoader):
                 Hosted models are passed in format "<provider>/<model>"
                 Examples: "azure/gpt-4o-mini", "vertex_ai/gemini-1.5-flash-001"
                           See more details in zerox documentation.
-            **zerox_kwargs: 
+            **zerox_kwargs:
                 Arguments specific to the zerox function.
                 see datailed list of arguments here in zerox repository:
                 https://github.com/getomni-ai/zerox/blob/main/py_zerox/pyzerox/core/zerox.py#L25


### PR DESCRIPTION
This PR allows to pass mime type to AmazonTextractPDFLoader.

This is useful for cases where files in S3 are stored without extension.