### PR TITLE
feat(document_loaders): add LandingAIADEDocumentLoader integration

### DIFF
--- a/libs/community/langchain_community/document_loaders/__init__.py
+++ b/libs/community/langchain_community/document_loaders/__init__.py
@@ -270,6 +270,9 @@ if TYPE_CHECKING:
     from langchain_community.document_loaders.lakefs import (
         LakeFSLoader,
     )
+    from langchain_community.document_loaders.landing_ai_ade import (
+        LandingAIADEDocumentLoader,
+    )
     from langchain_community.document_loaders.larksuite import (
         LarkSuiteDocLoader,
     )
@@ -626,6 +629,7 @@ _module_lookup = {
     "JoplinLoader": "langchain_community.document_loaders.joplin",
     "KineticaLoader": "langchain_community.document_loaders.kinetica_loader",
     "LakeFSLoader": "langchain_community.document_loaders.lakefs",
+    "LandingAIADEDocumentLoader": "langchain_community.document_loaders.landing_ai_ade",
     "LarkSuiteDocLoader": "langchain_community.document_loaders.larksuite",
     "LLMSherpaFileLoader": "langchain_community.document_loaders.llmsherpa",
     "MHTMLLoader": "langchain_community.document_loaders.mhtml",
@@ -834,6 +838,7 @@ __all__ = [
     "JSONLoader",
     "KineticaLoader",
     "LakeFSLoader",
+    "LandingAIADEDocumentLoader",
     "LarkSuiteDocLoader",
     "LLMSherpaFileLoader",
     "MastodonTootsLoader",

--- a/libs/community/langchain_community/document_loaders/landing_ai_ade.py
+++ b/libs/community/langchain_community/document_loaders/landing_ai_ade.py
@@ -1,7 +1,7 @@
 """Load documents using Landing AI's ADE (Agentic Document Extraction)."""
 
 from pathlib import Path
-from typing import Iterator, Optional, Union
+from typing import Iterator, Literal, Optional, Union
 from urllib.parse import urlparse
 
 from langchain_core.documents import Document
@@ -60,7 +60,7 @@ class LandingAIADEDocumentLoader(BaseLoader):
         file_path: Union[str, Path],
         api_key: Optional[str] = None,
         model: str = "dpt-2-latest",
-        environment: str = "production",
+        environment: Literal["production", "eu"] = "production",
         **kwargs: dict,
     ) -> None:
         """Initialize the loader.

--- a/libs/community/langchain_community/document_loaders/landing_ai_ade.py
+++ b/libs/community/langchain_community/document_loaders/landing_ai_ade.py
@@ -1,0 +1,132 @@
+"""Load documents using Landing AI's ADE (Agentic Document Extraction)."""
+
+from pathlib import Path
+from typing import Iterator, Optional, Union
+from urllib.parse import urlparse
+
+from langchain_core.documents import Document
+from langchain_core.utils import get_from_dict_or_env
+
+from langchain_community.document_loaders.base import BaseLoader
+
+
+class LandingAIADEDocumentLoader(BaseLoader):
+    """Load documents using Landing AI's ADE (Agentic Document Extraction).
+
+    Landing AI ADE is an intelligent document processing system that converts
+    various document formats into structured markdown with metadata.
+
+    Supported formats include:
+    - PDFs
+    - Images: JPEG, JPG, PNG, APNG, BMP, DCX, DDS, DIB, GD, GIF, ICNS, JP2, PCX,
+      PPM, PSD, TGA, TIFF, WEBP
+    - Text documents: DOC, DOCX, ODT
+    - Presentations: ODP, PPT, PPTX
+    - Spreadsheets: CSV, XLSX
+
+    To use this loader, you need a Landing AI API key. You can obtain one from:
+    https://va.landing.ai/my/settings/api-key
+
+    The API key can be passed directly or set as the VISION_AGENT_API_KEY
+    environment variable.
+
+    Example:
+        .. code-block:: python
+
+            from langchain_community.document_loaders import (
+                LandingAIADEDocumentLoader
+            )
+
+            loader = LandingAIADEDocumentLoader(
+                file_path="example.pdf",
+                api_key="your-api-key",
+                model="dpt-2-latest"
+            )
+            documents = loader.load()
+
+        For URL-based loading:
+
+        .. code-block:: python
+
+            loader = LandingAIADEDocumentLoader(
+                file_path="https://example.com/document.pdf",
+                api_key="your-api-key"
+            )
+            documents = loader.load()
+    """
+
+    def __init__(
+        self,
+        file_path: Union[str, Path],
+        api_key: Optional[str] = None,
+        model: str = "dpt-2-latest",
+        environment: str = "production",
+        **kwargs: dict,
+    ) -> None:
+        """Initialize the loader.
+
+        Args:
+            file_path: Path to the document file (local or URL).
+            api_key: Landing AI API key. If not provided, will look for
+                VISION_AGENT_API_KEY environment variable.
+            model: Model to use for document parsing.
+            environment: API environment (`'production'` or `'eu'`).
+            **kwargs: Additional keyword arguments.
+        """
+        self.file_path = str(file_path)
+        self.api_key = get_from_dict_or_env(
+            kwargs, "api_key", "VISION_AGENT_API_KEY", default=api_key
+        )
+        self.model = model
+        self.environment = environment
+
+        try:
+            from landingai_ade import LandingAIADE
+
+            self.client = LandingAIADE(
+                apikey=self.api_key, environment=self.environment
+            )
+        except ImportError:
+            msg = (
+                "Could not import landingai-ade python package. "
+                "Please install it with `pip install landingai-ade`."
+            )
+            raise ImportError(msg)
+
+    def lazy_load(self) -> Iterator[Document]:
+        """Lazily load documents from the file.
+
+        Yields:
+            Document objects with page content and metadata.
+        """
+        url_parse_result = urlparse(self.file_path)
+
+        if url_parse_result.scheme in ["http", "https"]:
+            response = self.client.parse(
+                document_url=self.file_path,
+                model=self.model,
+            )
+        else:
+            response = self.client.parse(
+                document=Path(self.file_path),
+                model=self.model,
+            )
+
+        for idx, chunk in enumerate(response.chunks):
+            metadata = {"source": self.file_path, "chunk": idx}
+
+            if chunk.grounding:
+                metadata["page"] = chunk.grounding.page
+
+            yield Document(
+                page_content=chunk.markdown,
+                metadata=metadata,
+            )
+
+    def load(self) -> list[Document]:
+        """Load documents from the file.
+
+        Returns:
+            List of Document objects.
+        """
+        return list(self.lazy_load())

--- a/libs/community/tests/integration_tests/document_loaders/test_landing_ai_ade.py
+++ b/libs/community/tests/integration_tests/document_loaders/test_landing_ai_ade.py
@@ -1,0 +1,60 @@
+"""Integration tests for LandingAIADEDocumentLoader."""
+
+import os
+from pathlib import Path
+
+import pytest
+
+
+@pytest.mark.skipif(
+    not os.environ.get("VISION_AGENT_API_KEY"),
+    reason="Landing AI API key not found",
+)
+def test_landing_ai_ade_loader_local_pdf() -> None:
+    """Test LandingAIADEDocumentLoader with local PDF."""
+    from langchain_community.document_loaders import LandingAIADEDocumentLoader
+
+    file_path = Path(__file__).parent.parent / "examples/hello.pdf"
+    loader = LandingAIADEDocumentLoader(file_path=file_path)
+    docs = loader.load()
+
+    assert len(docs) > 0
+    assert all(doc.page_content for doc in docs)
+    assert all("source" in doc.metadata for doc in docs)
+    assert all("chunk" in doc.metadata for doc in docs)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("VISION_AGENT_API_KEY"),
+    reason="Landing AI API key not found",
+)
+def test_landing_ai_ade_loader_url() -> None:
+    """Test LandingAIADEDocumentLoader with URL."""
+    from langchain_community.document_loaders import LandingAIADEDocumentLoader
+
+    url = "https://people.sc.fsu.edu/~jpeterson/hello_world.pdf"
+    loader = LandingAIADEDocumentLoader(file_path=url)
+    docs = loader.load()
+
+    assert len(docs) > 0
+    assert all(doc.page_content for doc in docs)
+    assert all(doc.metadata["source"] == url for doc in docs)
+
+
+@pytest.mark.skipif(
+    not os.environ.get("VISION_AGENT_API_KEY"),
+    reason="Landing AI API key not found",
+)
+def test_landing_ai_ade_loader_lazy_load() -> None:
+    """Test LandingAIADEDocumentLoader lazy_load method."""
+    from langchain_community.document_loaders import LandingAIADEDocumentLoader
+
+    file_path = Path(__file__).parent.parent / "examples/hello.pdf"
+    loader = LandingAIADEDocumentLoader(file_path=file_path)
+
+    docs = []
+    for doc in loader.lazy_load():
+        docs.append(doc)
+
+    assert len(docs) > 0
+    assert all(doc.page_content for doc in docs)

--- a/libs/community/tests/unit_tests/document_loaders/test_imports.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_imports.py
@@ -98,6 +98,7 @@ EXPECTED_ALL = [
     "LLMSherpaFileLoader",
     "LarkSuiteDocLoader",
     "LakeFSLoader",
+    "LandingAIADEDocumentLoader",
     "MHTMLLoader",
     "MWDumpLoader",
     "MastodonTootsLoader",


### PR DESCRIPTION
## Description

This PR adds a new document loader, called LandingAIADEDocumentLoader, to langchain_community.document_loaders that integrates the LandingAI ADE (Agentic Document Extraction). 

LandingAI ADE SDK references:
- https://docs.landing.ai/ade/ade-overview
- https://docs.landing.ai/ade/ade-python
- https://github.com/landing-ai/ade-python
- https://va.landing.ai

**Implementation Details:**
- New loader class: LandingAIADEDocumentLoader in libs/community/langchain_community/document_loaders
/landing_ai_ade.py
- Supports both local file paths and URLs
- Handles multiple document formats:
  - PDFs
  - Images: JPEG, JPG, PNG, APNG, BMP, DCX, DDS, DIB, GD, GIF, ICNS, JP2, PCX, PPM, PSD, TGA, TIFF, WEBP
  - Text documents: DOC, DOCX, ODT
  - Presentations: ODP, PPT, PPTX
  - Spreadsheets: CSV, XLSX
- Implements both load() and lazy_load() methods
- Configurable model selection and environment settings

**API Key Configuration:**
The Landing AI API key can be provided in two ways:
1. Directly via the api_key parameter
2. Via the VISION_AGENT_API_KEY environment variable

The loader automatically falls back to the environment variable if no key is provided directly. API keys can be obtained from: https://va.landing.ai/my/settings/api-key

**Returns:**
Each call returns Document objects with:
- page_content: The extracted markdown content from the document chunk
- metadata: Contains:
  - source: The original file path or URL
  - chunk: The chunk index
  - page: The page number (when grounding information is available)

**Tests:**
- Integration tests added in libs/community/tests/integration_tests/document_loaders/test_landing_ai_ade.py
- Tests cover:
  - Local PDF file loading
  - URL-based document loading
  - Lazy loading functionality
- Tests require VISION_AGENT_API_KEY environment variable to be set
- Run with: pytest tests/integration_tests/document_loaders/test_landing_ai_ade.py

```
dayoff@dayoff:~/codes/langchain-community/libs/community$ make integration_tests TEST_FILE=tests/integration_tests/document_loaders/test_landing_ai_ade.py
uv run --group test --group test_integration pytest tests/integration_tests/document_loaders/test_landing_ai_ade.py
==================================================================================== test session starts =====================================================================================
platform linux -- Python 3.13.9, pytest-8.4.2, pluggy-1.6.0 -- /home/dayoff/codes/langchain-community/libs/community/.venv/bin/python3
codspeed: 4.1.1 (disabled, mode: walltime, callgraph: enabled, timer_resolution: 1.0ns)
cachedir: .pytest_cache
benchmark: 5.1.0 (defaults: timer=time.perf_counter disable_gc=False min_rounds=5 min_time=0.000005 max_time=1.0 calibration_precision=10 warmup=False warmup_iterations=100000)
rootdir: /home/dayoff/codes/langchain-community/libs/community
configfile: pyproject.toml
plugins: recording-0.13.4, codspeed-4.1.1, langsmith-0.4.37, socket-0.7.0, cov-6.3.0, anyio-4.11.0, benchmark-5.1.0, syrupy-4.9.1, mock-3.15.1, dotenv-0.5.2, xdist-3.8.0, asyncio-0.26.0, requests-mock-1.12.1
asyncio: mode=Mode.AUTO, asyncio_default_fixture_loop_scope=function, asyncio_default_test_loop_scope=function
collected 3 items                                                                                                                                                                            

tests/integration_tests/document_loaders/test_landing_ai_ade.py::test_landing_ai_ade_loader_local_pdf PASSED                                                                           [ 33%]
tests/integration_tests/document_loaders/test_landing_ai_ade.py::test_landing_ai_ade_loader_url PASSED                                                                                 [ 66%]
tests/integration_tests/document_loaders/test_landing_ai_ade.py::test_landing_ai_ade_loader_lazy_load PASSED                                                                           [100%]

==================================================================================== slowest 5 durations =====================================================================================
8.24s call     tests/integration_tests/document_loaders/test_landing_ai_ade.py::test_landing_ai_ade_loader_url
4.66s call     tests/integration_tests/document_loaders/test_landing_ai_ade.py::test_landing_ai_ade_loader_lazy_load
3.89s call     tests/integration_tests/document_loaders/test_landing_ai_ade.py::test_landing_ai_ade_loader_local_pdf
0.00s setup    tests/integration_tests/document_loaders/test_landing_ai_ade.py::test_landing_ai_ade_loader_local_pdf
0.00s teardown tests/integration_tests/document_loaders/test_landing_ai_ade.py::test_landing_ai_ade_loader_lazy_load
===================================================================================== 3 passed in 16.80s =====================================================================================
```

**Dependencies:**
- No new hard dependencies added to pyproject.toml
- Runtime dependency: landingai-ade (optional, lazily imported)
  - Install with: pip install landingai-ade
  - Clear error message shown if package is missing

**Issue:**
N/A - New integration

**Usage example:**
<img width="2048" height="708" alt="carbon(3)" src="https://github.com/user-attachments/assets/22863b7f-7a3f-4378-b5ea-958a0aff534b" />