### PR TITLE
chore(retrievers): replace package `rank_bm25` with `bm25s`

### DIFF
--- a/libs/community/langchain_community/retrievers/bm25.py
+++ b/libs/community/langchain_community/retrievers/bm25.py
@@ -61,7 +61,9 @@ class BM25Retriever(BaseRetriever):
 
         texts_processed = [preprocess_func(t) for t in texts]
         bm25_params = bm25_params or {}
-        vectorizer = BM25(**bm25_params)
+        method = bm25_params.pop("method", "atire")
+        idf_method = bm25_params.pop("idf_method", "lucene")
+        vectorizer = BM25(method=method, idf_method=idf_method, **bm25_params)
         vectorizer.index(texts_processed)
         metadatas = metadatas or ({} for _ in texts)
         if ids:

--- a/libs/community/langchain_community/retrievers/bm25.py
+++ b/libs/community/langchain_community/retrievers/bm25.py
@@ -52,16 +52,15 @@ class BM25Retriever(BaseRetriever):
             A BM25Retriever instance.
         """
         try:
-            from rank_bm25 import BM25Okapi
+            from bm25s import BM25
         except ImportError:
             raise ImportError(
-                "Could not import rank_bm25, please install with `pip install "
-                "rank_bm25`."
+                "Could not import bm25s, please install with `pip install "
+                "bm25s`."
             )
 
         texts_processed = [preprocess_func(t) for t in texts]
         bm25_params = bm25_params or {}
-        vectorizer = BM25Okapi(texts_processed, **bm25_params)
         metadatas = metadatas or ({} for _ in texts)
         if ids:
             docs = [
@@ -72,8 +71,10 @@ class BM25Retriever(BaseRetriever):
             docs = [
                 Document(page_content=t, metadata=m) for t, m in zip(texts, metadatas)
             ]
+        bm25 = BM25(corpus=docs, **bm25_params)
+        bm25.index(texts_processed)
         return cls(
-            vectorizer=vectorizer, docs=docs, preprocess_func=preprocess_func, **kwargs
+            vectorizer=bm25, docs=docs, preprocess_func=preprocess_func, **kwargs
         )
 
     @classmethod
@@ -109,8 +110,23 @@ class BM25Retriever(BaseRetriever):
         )
 
     def _get_relevant_documents(
-        self, query: str, *, run_manager: CallbackManagerForRetrieverRun
+        self, query: str, *, run_manager: CallbackManagerForRetrieverRun, **kwargs: Any
     ) -> List[Document]:
+        # Cache self.vectorizer.retrieve() parameters
+        if not hasattr(self, "_retrieve_params"):
+            import inspect
+            self._retrieve_params = inspect.signature(self.vectorizer.retrieve).parameters
+        retrieve_params = self._retrieve_params
+        retrieve_kwargs = {
+            k: v for k, v in kwargs.items() if k in retrieve_params
+        }
+
         processed_query = self.preprocess_func(query)
-        return_docs = self.vectorizer.get_top_n(processed_query, self.docs, n=self.k)
-        return return_docs
+        results = self.vectorizer.retrieve(
+            query_tokens=[processed_query],
+            corpus=self.docs,
+            k=self.k,
+            return_as="documents",
+            **retrieve_kwargs   # for params like 'backend_selection', 'n_threads' ...
+        ) # np.ndarray of shape (num_queries, k), dtype=object; each entry is a Document
+        return list(results[0])

--- a/libs/community/langchain_community/retrievers/bm25.py
+++ b/libs/community/langchain_community/retrievers/bm25.py
@@ -61,6 +61,8 @@ class BM25Retriever(BaseRetriever):
 
         texts_processed = [preprocess_func(t) for t in texts]
         bm25_params = bm25_params or {}
+        vectorizer = BM25(**bm25_params)
+        vectorizer.index(texts_processed)
         metadatas = metadatas or ({} for _ in texts)
         if ids:
             docs = [
@@ -71,10 +73,8 @@ class BM25Retriever(BaseRetriever):
             docs = [
                 Document(page_content=t, metadata=m) for t, m in zip(texts, metadatas)
             ]
-        bm25 = BM25(corpus=docs, **bm25_params)
-        bm25.index(texts_processed)
         return cls(
-            vectorizer=bm25, docs=docs, preprocess_func=preprocess_func, **kwargs
+            vectorizer=vectorizer, docs=docs, preprocess_func=preprocess_func, **kwargs
         )
 
     @classmethod

--- a/libs/community/langchain_community/retrievers/bm25.py
+++ b/libs/community/langchain_community/retrievers/bm25.py
@@ -9,7 +9,8 @@ from pydantic import ConfigDict, Field
 
 
 def default_preprocessing_func(text: str) -> List[str]:
-    return text.split()
+    import re
+    return re.sub(r"[^a-zA-Z0-9\s]", " ", text.lower()).split()
 
 
 class BM25Retriever(BaseRetriever):

--- a/libs/community/tests/unit_tests/retrievers/test_bm25.py
+++ b/libs/community/tests/unit_tests/retrievers/test_bm25.py
@@ -4,63 +4,81 @@ from langchain_core.documents import Document
 from langchain_community.retrievers.bm25 import BM25Retriever
 
 
-@pytest.mark.requires("rank_bm25")
+@pytest.mark.requires("bm25s")
 def test_from_texts() -> None:
-    input_texts = ["I have a pen.", "Do you have a pen?", "I have a bag."]
+    input_texts = ["I have a pen.", "Do you have a pen?", "I have a bag.", "I like LangChain."]
+
     bm25_retriever = BM25Retriever.from_texts(texts=input_texts)
-    assert len(bm25_retriever.docs) == 3
-    assert bm25_retriever.vectorizer.doc_len == [4, 5, 4]
+    assert len(bm25_retriever.docs) == 4
+
+    results = bm25_retriever.invoke("pen")
+    assert len(results) == len(input_texts)
+    assert [d.page_content for d in results[:2]] == [
+        "I have a pen.",
+        "Do you have a pen?",
+    ]
 
 
-@pytest.mark.requires("rank_bm25")
+@pytest.mark.requires("bm25s")
 def test_from_texts_with_bm25_params() -> None:
-    input_texts = ["I have a pen.", "Do you have a pen?", "I have a bag."]
+    input_texts = ["I have a pen.", "Do you have a pen?", "I have a bag.", "I like LangChain."]
     bm25_retriever = BM25Retriever.from_texts(
-        texts=input_texts, bm25_params={"epsilon": 10}
+        texts=input_texts, bm25_params={"k1": 2.0, "b": 0.5, "delta": 0.0, "method": "lucene", "idf_method": "atire"},
     )
-    # should count only multiple words (have, pan)
-    assert bm25_retriever.vectorizer.epsilon == 10
+
+    assert bm25_retriever.vectorizer.k1 == 2.0
+    assert bm25_retriever.vectorizer.b == 0.5
+    assert bm25_retriever.vectorizer.delta == 0.0
+    assert bm25_retriever.vectorizer.method == "lucene"
+    assert bm25_retriever.vectorizer.idf_method == "atire"
 
 
-@pytest.mark.requires("rank_bm25")
+@pytest.mark.requires("bm25s")
 def test_from_documents() -> None:
     input_docs = [
         Document(page_content="I have a pen."),
         Document(page_content="Do you have a pen?"),
         Document(page_content="I have a bag."),
+        Document(page_content="I like LangChain."),
     ]
     bm25_retriever = BM25Retriever.from_documents(documents=input_docs)
-    assert len(bm25_retriever.docs) == 3
-    assert bm25_retriever.vectorizer.doc_len == [4, 5, 4]
+    assert len(bm25_retriever.docs) == 4
+
+    results = bm25_retriever.invoke("bag")
+    assert results[0].page_content == "I have a bag."
 
 
-@pytest.mark.requires("rank_bm25")
+@pytest.mark.requires("bm25s")
 def test_repr() -> None:
     input_docs = [
         Document(page_content="I have a pen."),
         Document(page_content="Do you have a pen?"),
         Document(page_content="I have a bag."),
+        Document(page_content="I like LangChain."),
     ]
     bm25_retriever = BM25Retriever.from_documents(documents=input_docs)
     assert "I have a pen" not in repr(bm25_retriever)
 
 
-@pytest.mark.requires("rank_bm25")
+@pytest.mark.requires("bm25s")
 def test_doc_id() -> None:
     docs_with_ids = [
         Document(page_content="I have a pen.", id="1"),
         Document(page_content="Do you have a pen?", id="2"),
         Document(page_content="I have a bag.", id="3"),
+        Document(page_content="I like LangChain.", id="4"),
     ]
     docs_without_ids = [
         Document(page_content="I have a pen."),
         Document(page_content="Do you have a pen?"),
         Document(page_content="I have a bag."),
+        Document(page_content="I like LangChain."),
     ]
     docs_with_some_ids = [
         Document(page_content="I have a pen.", id="1"),
         Document(page_content="Do you have a pen?"),
         Document(page_content="I have a bag.", id="3"),
+        Document(page_content="I like LangChain."),
     ]
     bm25_retriever_with_ids = BM25Retriever.from_documents(documents=docs_with_ids)
     bm25_retriever_without_ids = BM25Retriever.from_documents(
@@ -80,5 +98,7 @@ def test_doc_id() -> None:
             assert doc.id is None
         elif doc.page_content == "I have a bag.":
             assert doc.id == "3"
+        elif doc.page_content == "I like LangChain.":
+            assert doc.id is None
         else:
             raise ValueError("Unexpected document")


### PR DESCRIPTION
## Description 
Since [rank_bm25](https://github.com/dorianbrown/rank_bm25) is no longer actively maintained and relevant fixes have not been merged, this PR replaces it with [bm25s](https://github.com/xhluca/bm25s). Thanks @xhluca
  
This pull request updates the `BM25Retriever` implementation in libs/community/langchain_community/retrievers/bm25.py to use the `bm25s` package instead of `rank_bm25`, and refactors the code to work with the new API. 
Current updated code switched from `rank_bm25.BM25Okapi()` to `bm25s.BM25(method="atire", idf_method="lucene")`, `method="atire"` is standard Okapi BM25 tf / length normalization (behavior aligned with `rank_bm25.BM25Okapi`) and `idf_method="lucene"` uses a Lucene-style IDF that avoids negative values. More different method / idf_method combination setup see [variants](https://github.com/xhluca/bm25s?tab=readme-ov-file#variants).
It also improves `_get_relevant_documents` by dynamically forwarding only the supported keyword arguments to the `retrieve` method of the new BM25 implementation, enabling advanced options of `bm25s.BM25.retrieve()` such as `backend_selection` and `n_threads`.


## Unit Test
```bash
@toulzx ➜ /workspaces/langchain-community (chore/retrievers/bm25) $ python -m pytest libs/community/tests/unit_tests/retrievers/test_bm25.py -vv
================================================================= test session starts =================================================================
platform linux -- Python 3.12.1, pytest-9.0.2, pluggy-1.6.0 -- /home/codespace/.python/current/bin/python
cachedir: .pytest_cache
rootdir: /workspaces/langchain-community/libs/community
configfile: pyproject.toml
plugins: anyio-4.11.0, langsmith-0.4.59, syrupy-5.0.0
collected 5 items                                                                                                                                     

libs/community/tests/unit_tests/retrievers/test_bm25.py::test_from_texts PASSED                                                                 [ 20%]
libs/community/tests/unit_tests/retrievers/test_bm25.py::test_from_texts_with_bm25_params PASSED                                                [ 40%]
libs/community/tests/unit_tests/retrievers/test_bm25.py::test_from_documents PASSED                                                             [ 60%]
libs/community/tests/unit_tests/retrievers/test_bm25.py::test_repr PASSED                                                                       [ 80%]
libs/community/tests/unit_tests/retrievers/test_bm25.py::test_doc_id PASSED                                                                     [100%]
```


## Relevant Issue
no yet


## Dependencies Change
wont, not core dependency set


## Backwards Compatible
Not fully backwards compatible, but the impact should be limited. 
The constructor parameters of [`rank_bm25.BM25Okapi`](https://github.com/dorianbrown/rank_bm25/blob/master/rank_bm25.py) and [`bm25s.BM25`](https://github.com/xhluca/bm25s/blob/main/bm25s/__init__.py) do not overlap. If users were passing parameters intended for `rank_bm25.BM25Okapi` via `bm25_params` in `BM25Retriever.from_documents()` or `BM25Retriever.from_texts()`, those parameters will now cause errors because they are not valid for `bm25s.BM25`.


## Reference Version
+ [langchain-community](https://pypi.org/project/langchain-community/) v0.4.1
+ [bm25s](https://pypi.org/project/bm25s/) v0.2.14
+ [rank_bm25](https://pypi.org/project/rank-bm25/) v0.2.2

