### PR TITLE
fix(asknews): Add asknews api key support

### DIFF
--- a/libs/community/langchain_community/retrievers/asknews.py
+++ b/libs/community/langchain_community/retrievers/asknews.py
@@ -17,7 +17,7 @@ class AskNewsRetriever(BaseRetriever):
     offset: int = 0
     start_timestamp: Optional[int] = None
     end_timestamp: Optional[int] = None
-    method: Literal["nl", "kw"] = "nl"
+    method: Literal["nl", "kw"] = "kw"
     categories: List[
         Literal[
             "All",
@@ -42,6 +42,7 @@ class AskNewsRetriever(BaseRetriever):
     kwargs: Optional[Dict[str, Any]] = {}
     client_id: Optional[str] = None
     client_secret: Optional[str] = None
+    api_key: Optional[str] = None
 
     def _get_relevant_documents(
         self, query: str, *, run_manager: CallbackManagerForRetrieverRun
@@ -60,11 +61,37 @@ class AskNewsRetriever(BaseRetriever):
                 "AskNews python package not found. "
                 "Please install it with `pip install asknews`."
             )
-        an_client = AskNewsSDK(
-            client_id=self.client_id or os.environ["ASKNEWS_CLIENT_ID"],
-            client_secret=self.client_secret or os.environ["ASKNEWS_CLIENT_SECRET"],
-            scopes=["news"],
+
+        # Determine which authentication method to use
+        has_client_credentials = bool(
+            self.client_id or os.environ.get("ASKNEWS_CLIENT_ID")
         )
+        has_api_key = bool(self.api_key or os.environ.get("ASKNEWS_API_KEY"))
+
+        if has_client_credentials and has_api_key:
+            raise ValueError(
+                "Both client credentials and api_key provided. Please provide "
+                "either client credentials or API key, not both."
+            )
+
+        if not has_client_credentials and not has_api_key:
+            raise ValueError(
+                "No authentication credentials provided. Please provide either "
+                "client_id/client_secret or api_key."
+            )
+
+        # Initialize SDK with appropriate authentication method
+        if has_api_key:
+            an_client = AskNewsSDK(
+                api_key=self.api_key or os.environ["ASKNEWS_API_KEY"],
+                scopes=["news"],
+            )
+        else:
+            an_client = AskNewsSDK(
+                client_id=self.client_id or os.environ["ASKNEWS_CLIENT_ID"],
+                client_secret=self.client_secret or os.environ["ASKNEWS_CLIENT_SECRET"],
+                scopes=["news"],
+            )
         response = an_client.news.search_news(
             query=query,
             n_articles=self.k,
@@ -100,11 +127,37 @@ class AskNewsRetriever(BaseRetriever):
                 "AskNews python package not found. "
                 "Please install it with `pip install asknews`."
             )
-        an_client = AsyncAskNewsSDK(
-            client_id=self.client_id or os.environ["ASKNEWS_CLIENT_ID"],
-            client_secret=self.client_secret or os.environ["ASKNEWS_CLIENT_SECRET"],
-            scopes=["news"],
+
+        # Determine which authentication method to use
+        has_client_credentials = bool(
+            self.client_id or os.environ.get("ASKNEWS_CLIENT_ID")
         )
+        has_api_key = bool(self.api_key or os.environ.get("ASKNEWS_API_KEY"))
+
+        if has_client_credentials and has_api_key:
+            raise ValueError(
+                "Both client credentials and api_key provided. Please provide "
+                "either client credentials or API key, not both."
+            )
+
+        if not has_client_credentials and not has_api_key:
+            raise ValueError(
+                "No authentication credentials provided. Please provide either "
+                "client_id/client_secret or api_key."
+            )
+
+        # Initialize SDK with appropriate authentication method
+        if has_api_key:
+            an_client = AsyncAskNewsSDK(
+                api_key=self.api_key or os.environ["ASKNEWS_API_KEY"],
+                scopes=["news"],
+            )
+        else:
+            an_client = AsyncAskNewsSDK(
+                client_id=self.client_id or os.environ["ASKNEWS_CLIENT_ID"],
+                client_secret=self.client_secret or os.environ["ASKNEWS_CLIENT_SECRET"],
+                scopes=["news"],
+            )
         response = await an_client.news.search_news(
             query=query,
             n_articles=self.k,

--- a/libs/community/langchain_community/utilities/asknews.py
+++ b/libs/community/langchain_community/utilities/asknews.py
@@ -18,6 +18,8 @@ class AskNewsAPIWrapper(BaseModel):
     """Client ID for the AskNews API."""
     asknews_client_secret: Optional[str] = None
     """Client Secret for the AskNews API."""
+    asknews_api_key: Optional[str] = None
+    """API Key for the AskNews API."""
 
     model_config = ConfigDict(
         extra="forbid",
@@ -28,13 +30,6 @@ class AskNewsAPIWrapper(BaseModel):
     def validate_environment(cls, values: Dict) -> Any:
         """Validate that api credentials and python package exists in environment."""
 
-        asknews_client_id = get_from_dict_or_env(
-            values, "asknews_client_id", "ASKNEWS_CLIENT_ID"
-        )
-        asknews_client_secret = get_from_dict_or_env(
-            values, "asknews_client_secret", "ASKNEWS_CLIENT_SECRET"
-        )
-
         try:
             import asknews_sdk
 
@@ -44,21 +39,60 @@ class AskNewsAPIWrapper(BaseModel):
                 "Please install it with `pip install asknews`."
             )
 
-        an_sync = asknews_sdk.AskNewsSDK(
-            client_id=asknews_client_id,
-            client_secret=asknews_client_secret,
-            scopes=["news"],
+        # Try to get credentials, but don't require them yet
+        asknews_client_id = get_from_dict_or_env(
+            values, "asknews_client_id", "ASKNEWS_CLIENT_ID", default=None
         )
-        an_async = asknews_sdk.AsyncAskNewsSDK(
-            client_id=asknews_client_id,
-            client_secret=asknews_client_secret,
-            scopes=["news"],
+        asknews_client_secret = get_from_dict_or_env(
+            values, "asknews_client_secret", "ASKNEWS_CLIENT_SECRET", default=None
         )
+        asknews_api_key = get_from_dict_or_env(
+            values, "asknews_api_key", "ASKNEWS_API_KEY", default=None
+        )
+
+        # Determine which authentication method to use
+        has_client_credentials = bool(asknews_client_id and asknews_client_secret)
+        has_api_key = bool(asknews_api_key)
+
+        if has_client_credentials and has_api_key:
+            raise ValueError(
+                "Both client credentials and api_key provided. Please provide "
+                "either client credentials or API key, not both."
+            )
+
+        if not has_client_credentials and not has_api_key:
+            raise ValueError(
+                "No authentication credentials provided. Please provide either "
+                "asknews_client_id/asknews_client_secret or asknews_api_key."
+            )
+
+        # Initialize SDK with appropriate authentication method
+        if has_api_key:
+            an_sync = asknews_sdk.AskNewsSDK(
+                api_key=asknews_api_key,
+                scopes=["news"],
+            )
+            an_async = asknews_sdk.AsyncAskNewsSDK(
+                api_key=asknews_api_key,
+                scopes=["news"],
+            )
+        else:
+            an_sync = asknews_sdk.AskNewsSDK(
+                client_id=asknews_client_id,
+                client_secret=asknews_client_secret,
+                scopes=["news"],
+            )
+            an_async = asknews_sdk.AsyncAskNewsSDK(
+                client_id=asknews_client_id,
+                client_secret=asknews_client_secret,
+                scopes=["news"],
+            )
 
         values["asknews_sync"] = an_sync
         values["asknews_async"] = an_async
         values["asknews_client_id"] = asknews_client_id
         values["asknews_client_secret"] = asknews_client_secret
+        values["asknews_api_key"] = asknews_api_key
 
         return values
 
@@ -66,24 +100,12 @@ class AskNewsAPIWrapper(BaseModel):
         self, query: str, max_results: int = 10, hours_back: int = 0
     ) -> str:
         """Search news in AskNews API synchronously."""
-        if hours_back > 48:
-            method = "kw"
-            historical = True
-            start = int((datetime.now() - timedelta(hours=hours_back)).timestamp())
-            stop = int(datetime.now().timestamp())
-        else:
-            historical = False
-            method = "nl"
-            start = None
-            stop = None
 
         response = self.asknews_sync.news.search_news(
             query=query,
             n_articles=max_results,
-            method=method,
-            historical=historical,
-            start_timestamp=start,
-            end_timestamp=stop,
+            method="kw",
+            hours_back=hours_back,
             return_type="string",
         )
         return response.as_string
@@ -92,24 +114,11 @@ class AskNewsAPIWrapper(BaseModel):
         self, query: str, max_results: int = 10, hours_back: int = 0
     ) -> str:
         """Search news in AskNews API asynchronously."""
-        if hours_back > 48:
-            method = "kw"
-            historical = True
-            start = int((datetime.now() - timedelta(hours=hours_back)).timestamp())
-            stop = int(datetime.now().timestamp())
-        else:
-            historical = False
-            method = "nl"
-            start = None
-            stop = None
-
         response = await self.asknews_async.news.search_news(
             query=query,
             n_articles=max_results,
-            method=method,
-            historical=historical,
-            start_timestamp=start,
-            end_timestamp=stop,
+            method="kw",
+            hours_back=hours_back,
             return_type="string",
         )
         return response.as_string


### PR DESCRIPTION
Description: We add support for API keys in the AskNews Retriever and Tool. OAuth2 credentials are still supported, so we check to ensure both are not passed at the same time. We also update some changes to parameters to improve retrieval performance based on latest automations/deprecations inside AskNews.

Issue: Users couldn't use AskNews API keys, only OAuth2 creds.
