### PR TITLE
feat(retrievers): Add option to set author, title etc. in `ArxivRetriever`

### DIFF
--- a/libs/community/langchain_community/retrievers/arxiv.py
+++ b/libs/community/langchain_community/retrievers/arxiv.py
@@ -20,7 +20,7 @@ class ArxivRetriever(BaseRetriever, ArxivAPIWrapper):
     Key init args:
         load_max_docs: int
             maximum number of documents to load
-        get_ful_documents: bool
+        get_full_documents: bool
             whether to return full document text or snippets
 
     Instantiate:
@@ -30,7 +30,7 @@ class ArxivRetriever(BaseRetriever, ArxivAPIWrapper):
 
             retriever = ArxivRetriever(
                 load_max_docs=2,
-                get_ful_documents=True,
+                get_full_documents=True,
             )
 
     Usage:
@@ -84,8 +84,25 @@ class ArxivRetriever(BaseRetriever, ArxivAPIWrapper):
     get_full_documents: bool = False
 
     def _get_relevant_documents(
-        self, query: str, *, run_manager: CallbackManagerForRetrieverRun
+        self, query: str, *, run_manager: CallbackManagerForRetrieverRun,
+        **kwargs
     ) -> List[Document]:
+
+        arxiv_api_prefixes = [
+            ("ti", "title"),
+            ("au", "author"),
+            ("abs", "abstract"),
+            ("co", "comment"),
+            ("jr", "journal_reference"),
+            ("cat", "category"),
+            ("rn", "report_number"),
+        ]
+
+        for key, full_name in arxiv_api_prefixes:
+            if value := (kwargs.get(full_name) or kwargs.get(key)):
+                if f"{key}:" not in query:
+                    query = f"{query} AND {key}:{value.replace(' ', '+')}"
+
         if self.get_full_documents:
             return self.load(query=query)
         else:

--- a/libs/community/langchain_community/retrievers/arxiv.py
+++ b/libs/community/langchain_community/retrievers/arxiv.py
@@ -1,4 +1,4 @@
-from typing import List
+from typing import Any, List
 
 from langchain_core.callbacks import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
@@ -84,10 +84,8 @@ class ArxivRetriever(BaseRetriever, ArxivAPIWrapper):
     get_full_documents: bool = False
 
     def _get_relevant_documents(
-        self, query: str, *, run_manager: CallbackManagerForRetrieverRun,
-        **kwargs
+        self, query: str, *, run_manager: CallbackManagerForRetrieverRun, **kwargs: Any
     ) -> List[Document]:
-
         arxiv_api_prefixes = [
             ("ti", "title"),
             ("au", "author"),

--- a/libs/community/langchain_community/utilities/arxiv.py
+++ b/libs/community/langchain_community/utilities/arxiv.py
@@ -1,9 +1,11 @@
 """Util that calls Arxiv."""
 
 import logging
+import tempfile
 import os
 import re
 from typing import Any, Dict, Iterator, List, Optional
+from urllib.request import urlretrieve
 
 from langchain_core.documents import Document
 from pydantic import BaseModel, model_validator
@@ -53,6 +55,7 @@ class ArxivAPIWrapper(BaseModel):
     """
 
     arxiv_search: Any
+    arxiv_client: Any
     arxiv_exceptions: Any
     top_k_results: int = 3
     ARXIV_MAX_QUERY_LENGTH: int = 300
@@ -81,6 +84,7 @@ class ArxivAPIWrapper(BaseModel):
             import arxiv
 
             values["arxiv_search"] = arxiv.Search
+            values["arxiv_client"] = arxiv.Client()
             values["arxiv_exceptions"] = (
                 arxiv.ArxivError,
                 arxiv.UnexpectedEmptyPageError,
@@ -96,13 +100,16 @@ class ArxivAPIWrapper(BaseModel):
 
     def _fetch_results(self, query: str) -> Any:
         """Helper function to fetch arxiv results based on query."""
+        max_results = min(self.load_max_docs, self.top_k_results)
         if self.is_arxiv_identifier(query):
-            return self.arxiv_search(
-                id_list=query.split(), max_results=self.top_k_results
-            ).results()
-        return self.arxiv_search(
-            query[: self.ARXIV_MAX_QUERY_LENGTH], max_results=self.top_k_results
-        ).results()
+            search = self.arxiv_search(
+                id_list=query.split(), max_results=max_results
+            )
+        else:
+            search = self.arxiv_search(
+                query[: self.ARXIV_MAX_QUERY_LENGTH], max_results=max_results
+            )
+        return self.arxiv_client.results(search)
 
     def get_summaries_as_docs(self, query: str) -> List[Document]:
         """
@@ -216,19 +223,22 @@ class ArxivAPIWrapper(BaseModel):
             return
 
         for result in results:
-            try:
-                doc_file_name: str = result.download_pdf()
-                with fitz.open(doc_file_name) as doc_file:
-                    text: str = "".join(page.get_text() for page in doc_file)
-            except (FileNotFoundError, fitz.fitz.FileDataError) as f_ex:
-                logger.debug(f_ex)
-                continue
-            except Exception as e:
-                if self.continue_on_failure:
-                    logger.error(e)
+            result_pdf = result.pdf_url
+            with tempfile.TemporaryDirectory() as tmpdir:
+                try:
+                    doc_file_name = os.path.join(tmpdir, "tmp.pdf")
+                    urlretrieve(result_pdf, doc_file_name)
+                    with fitz.open(doc_file_name) as doc_file:
+                        text: str = "".join(page.get_text() for page in doc_file)
+                except (FileNotFoundError, fitz.FileDataError) as f_ex:
+                    logger.debug(f_ex)
                     continue
-                else:
-                    raise e
+                except Exception as e:
+                    if self.continue_on_failure:
+                        logger.error(e)
+                        continue
+                    else:
+                        raise e
             if self.load_all_available_meta:
                 extra_metadata = {
                     "entry_id": result.entry_id,
@@ -252,4 +262,3 @@ class ArxivAPIWrapper(BaseModel):
             yield Document(
                 page_content=text[: self.doc_content_chars_max], metadata=metadata
             )
-            os.remove(doc_file_name)

--- a/libs/community/langchain_community/utilities/arxiv.py
+++ b/libs/community/langchain_community/utilities/arxiv.py
@@ -1,9 +1,9 @@
 """Util that calls Arxiv."""
 
 import logging
-import tempfile
 import os
 import re
+import tempfile
 from typing import Any, Dict, Iterator, List, Optional
 from urllib.request import urlretrieve
 
@@ -102,9 +102,7 @@ class ArxivAPIWrapper(BaseModel):
         """Helper function to fetch arxiv results based on query."""
         max_results = min(self.load_max_docs, self.top_k_results)
         if self.is_arxiv_identifier(query):
-            search = self.arxiv_search(
-                id_list=query.split(), max_results=max_results
-            )
+            search = self.arxiv_search(id_list=query.split(), max_results=max_results)
         else:
             search = self.arxiv_search(
                 query[: self.ARXIV_MAX_QUERY_LENGTH], max_results=max_results

--- a/libs/community/tests/integration_tests/retrievers/test_arxiv.py
+++ b/libs/community/tests/integration_tests/retrievers/test_arxiv.py
@@ -40,8 +40,9 @@ def test_load_success_all_meta(retriever: ArxivRetriever) -> None:
 
 
 def test_load_success_init_args() -> None:
-    retriever = ArxivRetriever(load_max_docs=1, load_all_available_meta=True,
-                               get_full_documents=True)  # type: ignore[call-arg]
+    retriever = ArxivRetriever(
+        load_max_docs=1, load_all_available_meta=True, get_full_documents=True
+    )  # type: ignore[call-arg]
     docs = retriever.invoke("ChatGPT")
     assert len(docs) == 1
     assert_docs(docs, all_meta=True)

--- a/libs/community/tests/integration_tests/retrievers/test_arxiv.py
+++ b/libs/community/tests/integration_tests/retrievers/test_arxiv.py
@@ -10,7 +10,7 @@ from langchain_community.retrievers import ArxivRetriever
 
 @pytest.fixture
 def retriever() -> ArxivRetriever:
-    return ArxivRetriever()  # type: ignore[call-arg]
+    return ArxivRetriever(get_full_documents=True)  # type: ignore[call-arg]
 
 
 def assert_docs(docs: List[Document], all_meta: bool = False) -> None:
@@ -40,7 +40,8 @@ def test_load_success_all_meta(retriever: ArxivRetriever) -> None:
 
 
 def test_load_success_init_args() -> None:
-    retriever = ArxivRetriever(load_max_docs=1, load_all_available_meta=True)  # type: ignore[call-arg]
+    retriever = ArxivRetriever(load_max_docs=1, load_all_available_meta=True,
+                               get_full_documents=True)  # type: ignore[call-arg]
     docs = retriever.invoke("ChatGPT")
     assert len(docs) == 1
     assert_docs(docs, all_meta=True)


### PR DESCRIPTION
This PR 
- updates the ArXiv search functionality to use arxiv.Client` instead of the deprecated `arxiv.Search`}
- fixes the `ArxivRetriever` tests
- fixes the file handling in `lazy_load` (also because the function from the arxiv lib will be deprecated)
- adds the possibility to invoke the retriever with optional kwargs `author`, `title`, ... (see [the details of query construction](https://info.arxiv.org/help/api/user-manual.html#query_details)) to simplify the usage of the retriever. 