### PR TITLE
Fix/chatgpt loader bug

### DIFF
--- a/libs/community/langchain_community/document_loaders/chatgpt.py
+++ b/libs/community/langchain_community/document_loaders/chatgpt.py
@@ -31,7 +31,7 @@ def concatenate_rows(message: dict, title: str) -> str:
 class ChatGPTLoader(BaseLoader):
     """Load conversations from exported `ChatGPT` data."""
 
-    def __init__(self, log_file: str, num_logs: int = -1):
+    def __init__(self, log_file: str, num_logs: int = 0):
         """Initialize a class object.
 
         Args:

--- a/libs/community/tests/unit_tests/document_loaders/test_chatgpt.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_chatgpt.py
@@ -1,0 +1,73 @@
+import json
+from pathlib import Path
+from langchain_community.document_loaders.chatgpt import ChatGPTLoader
+
+def test_chatgpt_loader_load(tmp_path: Path) -> None:
+    """Test loading conversations from a fake ChatGPT export file."""
+
+    # 1. Arrange: 準備一個模擬的 ChatGPT JSON 檔案
+    file_path = tmp_path / "logs.json"
+    mock_data = [
+        {
+            "title": "Test Conversation",
+            "create_time": 1678888888,
+            "mapping": {
+                "aaa-bbb-ccc": {
+                    "message": {
+                        "author": {"role": "system"},
+                        "create_time": 1678888888.0,
+                        "content": {"parts": ["System prompt"]},
+                    }
+                },
+                "ddd-eee-fff": {
+                    "message": {
+                        "author": {"role": "user"},
+                        "create_time": 1678888890.0,
+                        "content": {"parts": ["Hello AI"]},
+                    }
+                },
+                "ggg-hhh-iii": {
+                    "message": {
+                        "author": {"role": "assistant"},
+                        "create_time": 1678888900.0,
+                        "content": {"parts": ["Hello Human"]},
+                    }
+                },
+            },
+        }
+    ]
+    file_path.write_text(json.dumps(mock_data), encoding="utf-8")
+
+    # 2. Act: 執行 Loader
+    loader = ChatGPTLoader(str(file_path))
+    docs = loader.load()
+
+    # 3. Assert: 驗證結果
+    assert len(docs) == 1
+    assert docs[0].metadata["source"] == str(file_path)
+
+    # 驗證內容 (根據 chatgpt.py 的 concatenate_rows 邏輯)
+    content = docs[0].page_content
+    assert "Test Conversation - user on" in content
+    assert "Hello AI" in content
+    assert "Test Conversation - assistant on" in content
+    assert "Hello Human" in content
+
+    # 驗證它是否正確跳過了第一個 system message (chatgpt.py 的邏輯有過濾 idx==0 且 role==system)
+    assert "System prompt" not in content
+
+def test_chatgpt_loader_num_logs(tmp_path: Path) -> None:
+    """Test checking limits on number of logs loaded."""
+    file_path = tmp_path / "logs.json"
+    # 建立兩個對話紀錄
+    mock_data = [
+        {"title": "Conv 1", "mapping": {}},
+        {"title": "Conv 2", "mapping": {}}
+    ]
+    file_path.write_text(json.dumps(mock_data), encoding="utf-8")
+
+    # 設定 num_logs=1
+    loader = ChatGPTLoader(str(file_path), num_logs=1)
+    docs = loader.load()
+
+    assert len(docs) == 1

--- a/libs/community/tests/unit_tests/document_loaders/test_chatgpt.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_chatgpt.py
@@ -1,11 +1,13 @@
 import json
 from pathlib import Path
+
 from langchain_community.document_loaders.chatgpt import ChatGPTLoader
+
 
 def test_chatgpt_loader_load(tmp_path: Path) -> None:
     """Test loading conversations from a fake ChatGPT export file."""
 
-    # 1. Arrange: 準備一個模擬的 ChatGPT JSON 檔案
+    # 1. Arrange: Prepare a mock ChatGPT JSON file
     file_path = tmp_path / "logs.json"
     mock_data = [
         {
@@ -38,35 +40,36 @@ def test_chatgpt_loader_load(tmp_path: Path) -> None:
     ]
     file_path.write_text(json.dumps(mock_data), encoding="utf-8")
 
-    # 2. Act: 執行 Loader
+    # 2. Act: Run Loader
     loader = ChatGPTLoader(str(file_path))
     docs = loader.load()
 
-    # 3. Assert: 驗證結果
+    # 3. Assert: Verify results
     assert len(docs) == 1
     assert docs[0].metadata["source"] == str(file_path)
 
-    # 驗證內容 (根據 chatgpt.py 的 concatenate_rows 邏輯)
+    # Verify content
     content = docs[0].page_content
     assert "Test Conversation - user on" in content
     assert "Hello AI" in content
     assert "Test Conversation - assistant on" in content
     assert "Hello Human" in content
 
-    # 驗證它是否正確跳過了第一個 system message (chatgpt.py 的邏輯有過濾 idx==0 且 role==system)
+    # Verify it correctly skipped the first system message
     assert "System prompt" not in content
+
 
 def test_chatgpt_loader_num_logs(tmp_path: Path) -> None:
     """Test checking limits on number of logs loaded."""
     file_path = tmp_path / "logs.json"
-    # 建立兩個對話紀錄
+    # Create mock data with 2 conversations
     mock_data = [
         {"title": "Conv 1", "mapping": {}},
-        {"title": "Conv 2", "mapping": {}}
+        {"title": "Conv 2", "mapping": {}},
     ]
     file_path.write_text(json.dumps(mock_data), encoding="utf-8")
 
-    # 設定 num_logs=1
+    # Set num_logs=1
     loader = ChatGPTLoader(str(file_path), num_logs=1)
     docs = loader.load()
 


### PR DESCRIPTION
## Description

This PR fixes a bug in `ChatGPTLoader` where the last message in the conversation was being dropped when using the default initialization arguments.

**The Bug:**
The `__init__` method had a default value of `num_logs=-1`. In the `load` method, the code used slicing `data[:self.num_logs]` when `num_logs` was truthy. Since `-1` is truthy, this resulted in `data[:-1]`, which excluded the last element of the list.

**The Fix:**
Changed the default value of `num_logs` to `0` (which implies loading all logs), ensuring the slicing logic correctly handles the default case.

**Testing:**
- Added a new test file `tests/unit_tests/document_loaders/test_chatgpt.py`.
- Added unit tests to verify correct loading of conversation data.
- Verified that `num_logs` parameter works as expected.
- **Coverage:** Increased code coverage for `chatgpt.py` from **0% to 100%**.

## Issue
Fixes #465 

## Dependencies
None