### PR TITLE
Add PraisonAI tools for multi-agent workflows

### DIFF
--- a/libs/community/langchain_community/tools/__init__.py
+++ b/libs/community/langchain_community/tools/__init__.py
@@ -216,6 +216,10 @@ if TYPE_CHECKING:
     from langchain_community.tools.openweathermap.tool import (
         OpenWeatherMapQueryRun,
     )
+    from langchain_community.tools.praisonai import (
+        PraisonAIAgentTool,
+        PraisonAITool,
+    )
     from langchain_community.tools.playwright import (
         ClickTool,
         CurrentWebPageTool,
@@ -450,6 +454,8 @@ __all__ = [
     "PolygonFinancials",
     "PolygonLastQuote",
     "PolygonTickerNews",
+    "PraisonAIAgentTool",
+    "PraisonAITool",
     "PubmedQueryRun",
     "QueryCheckerTool",
     "QueryPowerBITool",
@@ -604,6 +610,8 @@ _module_lookup = {
     "PolygonFinancials": "langchain_community.tools.polygon.financials",
     "PolygonLastQuote": "langchain_community.tools.polygon.last_quote",
     "PolygonTickerNews": "langchain_community.tools.polygon.ticker_news",
+    "PraisonAIAgentTool": "langchain_community.tools.praisonai",
+    "PraisonAITool": "langchain_community.tools.praisonai",
     "PubmedQueryRun": "langchain_community.tools.pubmed.tool",
     "QueryCheckerTool": "langchain_community.tools.spark_sql.tool",
     "QueryPowerBITool": "langchain_community.tools.powerbi.tool",

--- a/libs/community/langchain_community/tools/praisonai/__init__.py
+++ b/libs/community/langchain_community/tools/praisonai/__init__.py
@@ -1,0 +1,8 @@
+"""PraisonAI tools for LangChain."""
+
+from langchain_community.tools.praisonai.tool import (
+    PraisonAITool,
+    PraisonAIAgentTool,
+)
+
+__all__ = ["PraisonAITool", "PraisonAIAgentTool"]

--- a/libs/community/langchain_community/tools/praisonai/tool.py
+++ b/libs/community/langchain_community/tools/praisonai/tool.py
@@ -1,0 +1,90 @@
+"""PraisonAI tools for running multi-agent workflows."""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+import httpx
+from langchain_core.callbacks import CallbackManagerForToolRun
+from langchain_core.tools import BaseTool
+from pydantic import Field
+
+
+class PraisonAITool(BaseTool):
+    """Tool for running queries through a PraisonAI multi-agent workflow.
+
+    Example usage:
+    .. code-block:: python
+
+        tool = PraisonAITool(api_url="http://localhost:8080")
+        result = tool.run("Research AI trends")
+    """
+
+    name: str = "praisonai"
+    description: str = (
+        "A multi-agent AI workflow tool. "
+        "Useful for complex tasks that benefit from multiple AI agents "
+        "working together. Input should be a query or task description."
+    )
+    api_url: str = Field(default="http://localhost:8080")
+    timeout: int = Field(default=300)
+
+    def _run(
+        self,
+        query: str,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Run the query through PraisonAI."""
+        response = httpx.post(
+            f"{self.api_url}/agents",
+            json={"query": query},
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        return response.json().get("response", "")
+
+
+class PraisonAIAgentTool(BaseTool):
+    """Tool for running queries through a specific PraisonAI agent.
+
+    Example usage:
+    .. code-block:: python
+
+        tool = PraisonAIAgentTool(
+            api_url="http://localhost:8080",
+            agent_name="researcher"
+        )
+        result = tool.run("Find latest AI papers")
+    """
+
+    name: str = "praisonai_agent"
+    description: str = (
+        "Run a query through a specific AI agent. "
+        "Input should be a query or task description."
+    )
+    api_url: str = Field(default="http://localhost:8080")
+    agent_name: str = Field(description="Name of the agent to use")
+    timeout: int = Field(default=300)
+
+    def __init__(self, agent_name: str, **kwargs: Any) -> None:
+        """Initialize with agent name."""
+        super().__init__(agent_name=agent_name, **kwargs)
+        self.name = f"praisonai_{agent_name}"
+        self.description = (
+            f"Run a query through the '{agent_name}' AI agent. "
+            "Input should be a query or task description."
+        )
+
+    def _run(
+        self,
+        query: str,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Run the query through the specific agent."""
+        response = httpx.post(
+            f"{self.api_url}/agents/{self.agent_name}",
+            json={"query": query},
+            timeout=self.timeout,
+        )
+        response.raise_for_status()
+        return response.json().get("response", "")


### PR DESCRIPTION
## Description

Adds community tools for interacting with PraisonAI multi-agent workflows.

## New Tools

- **PraisonAITool**: Run queries through a PraisonAI multi-agent workflow
- **PraisonAIAgentTool**: Run queries through a specific PraisonAI agent

## Usage

```python
from langchain_community.tools.praisonai import PraisonAITool

tool = PraisonAITool(api_url="http://localhost:8080")
result = tool.run("Research AI trends")
```

## Dependencies

- Uses `httpx` for HTTP requests (already a dependency of langchain-community)

## Checklist

- [x] Follows existing tool structure pattern
- [x] Added to `__init__.py` exports
- [x] Added to `_module_lookup` for lazy loading
- [x] Includes docstrings with examples