### PR TITLE
feat: opensearch add asynchronous similarity search methods and refac…

### DIFF
--- a/libs/community/langchain_community/vectorstores/opensearch_vector_search.py
+++ b/libs/community/langchain_community/vectorstores/opensearch_vector_search.py
@@ -978,6 +978,27 @@ class OpenSearchVectorSearch(VectorStore):
         """
         return self._identity_fn
 
+    def _hits_to_documents(
+        self, hits: List[dict], text_field: str, metadata_field: str
+    ) -> List[Tuple[Document, float]]:
+        """Parse OpenSearch hits into a list of Documents with scores."""
+        documents_with_scores = [
+            (
+                Document(
+                    page_content=hit["_source"][text_field],
+                    metadata=(
+                        hit["_source"]
+                        if metadata_field == "*" or metadata_field not in hit["_source"]
+                        else hit["_source"][metadata_field]
+                    ),
+                    id=hit["_id"],
+                ),
+                hit["_score"],
+            )
+            for hit in hits
+        ]
+        return documents_with_scores
+
     def similarity_search(
         self,
         query: str,
@@ -1123,22 +1144,7 @@ class OpenSearchVectorSearch(VectorStore):
             embedding=embedding, k=k, score_threshold=score_threshold, **kwargs
         )
 
-        documents_with_scores = [
-            (
-                Document(
-                    page_content=hit["_source"][text_field],
-                    metadata=(
-                        hit["_source"]
-                        if metadata_field == "*" or metadata_field not in hit["_source"]
-                        else hit["_source"][metadata_field]
-                    ),
-                    id=hit["_id"],
-                ),
-                hit["_score"],
-            )
-            for hit in hits
-        ]
-        return documents_with_scores
+        return self._hits_to_documents(hits, text_field, metadata_field)
 
     def _raw_similarity_search_with_score_by_vector(
         self,
@@ -1814,3 +1820,244 @@ class OpenSearchVectorSearch(VectorStore):
         kwargs["engine"] = engine
         kwargs["routing"] = routing
         return cls(opensearch_url, index_name, embedding, **kwargs)
+
+    async def asimilarity_search_with_score(
+        self,
+        query: str,
+        k: int = 4,
+        score_threshold: Optional[float] = 0.0,
+        **kwargs: Any,
+    ) -> List[Tuple[Document, float]]:
+        """Asynchronously return docs and their scores most similar to query.
+
+        Args:
+            query: Text to look up documents similar to.
+            k: Number of Documents to return. Defaults to 4.
+            score_threshold: Specify a score threshold to return only documents
+            above the threshold. Defaults to 0.0.
+
+        Returns:
+            List of Documents along with its scores most similar to the query.
+        """
+        # Added query_text to kwargs for Hybrid Search
+        kwargs["query_text"] = query
+
+        # IMPORTANT: Use async embedding
+        embedding = await self.embedding_function.aembed_query(query)
+
+        return await self.asimilarity_search_with_score_by_vector(
+            embedding, k, score_threshold, **kwargs
+        )
+
+    async def asimilarity_search_with_score_by_vector(
+        self,
+        embedding: List[float],
+        k: int = 4,
+        score_threshold: Optional[float] = 0.0,
+        **kwargs: Any,
+    ) -> List[Tuple[Document, float]]:
+        """Asynchronously return docs and their scores most similar to the
+        embedding vector.
+        """
+        text_field = kwargs.get("text_field", "text")
+        metadata_field = kwargs.get("metadata_field", "metadata")
+
+        hits = await self._araw_similarity_search_with_score_by_vector(
+            embedding=embedding, k=k, score_threshold=score_threshold, **kwargs
+        )
+
+        return self._hits_to_documents(hits, text_field, metadata_field)
+
+    async def asimilarity_search(
+        self,
+        query: str,
+        k: int = 4,
+        score_threshold: Optional[float] = 0.0,
+        **kwargs: Any,
+    ) -> List[Document]:
+        """Asynchronously return docs most similar to query."""
+        docs_with_scores = await self.asimilarity_search_with_score(
+            query, k, score_threshold, **kwargs
+        )
+        return [doc[0] for doc in docs_with_scores]
+
+    async def _araw_similarity_search_with_score_by_vector(
+        self,
+        embedding: List[float],
+        k: int = 4,
+        score_threshold: Optional[float] = 0.0,
+        **kwargs: Any,
+    ) -> List[dict]:
+        """Asynchronously return raw opensearch documents (dict) including vectors,
+        scores most similar to the embedding vector.
+
+        By default, supports Approximate Search.
+        Also supports Script Scoring and Painless Scripting.
+
+        Args:
+            embedding: Embedding vector to look up documents similar to.
+            k: Number of Documents to return. Defaults to 4.
+            score_threshold: Specify a score threshold to return only documents
+            above the threshold. Defaults to 0.0.
+
+        Returns:
+            List of dict with its scores most similar to the embedding.
+
+        Optional Args:
+            same as `similarity_search`
+        """
+        search_type = kwargs.get("search_type", "approximate_search")
+        vector_field = kwargs.get("vector_field", "vector_field")
+        index_name = kwargs.get("index_name", self.index_name)
+        if self.index_name is None:
+            raise ValueError("index_name must be provided.")
+        filter = kwargs.get("filter", {})
+
+        if (
+            self.is_aoss
+            and search_type != "approximate_search"
+            and search_type != SCRIPT_SCORING_SEARCH
+        ):
+            raise ValueError(
+                "Amazon OpenSearch Service Serverless only "
+                "supports `approximate_search` and `script_scoring`"
+            )
+
+        if search_type == "approximate_search":
+            boolean_filter = kwargs.get("boolean_filter", {})
+            subquery_clause = kwargs.get("subquery_clause", "must")
+            efficient_filter = kwargs.get("efficient_filter", {})
+            # `lucene_filter` is deprecated, added for Backwards Compatibility
+            lucene_filter = kwargs.get("lucene_filter", {})
+
+            if boolean_filter != {} and efficient_filter != {}:
+                raise ValueError(
+                    "Both `boolean_filter` and `efficient_filter` are provided which "
+                    "is invalid"
+                )
+
+            if lucene_filter != {} and efficient_filter != {}:
+                raise ValueError(
+                    "Both `lucene_filter` and `efficient_filter` are provided which "
+                    "is invalid. `lucene_filter` is deprecated"
+                )
+
+            if lucene_filter != {} and boolean_filter != {}:
+                raise ValueError(
+                    "Both `lucene_filter` and `boolean_filter` are provided which "
+                    "is invalid. `lucene_filter` is deprecated"
+                )
+
+            if (
+                efficient_filter == {}
+                and boolean_filter == {}
+                and lucene_filter == {}
+                and filter != {}
+            ):
+                if self.engine in ["faiss", "lucene"]:
+                    efficient_filter = filter
+                else:
+                    boolean_filter = filter
+
+            if boolean_filter != {}:
+                search_query = _approximate_search_query_with_boolean_filter(
+                    embedding,
+                    boolean_filter,
+                    k=k,
+                    vector_field=vector_field,
+                    subquery_clause=subquery_clause,
+                    score_threshold=score_threshold,
+                )
+            elif efficient_filter != {}:
+                search_query = _approximate_search_query_with_efficient_filter(
+                    embedding,
+                    efficient_filter,
+                    k=k,
+                    vector_field=vector_field,
+                    score_threshold=score_threshold,
+                )
+            elif lucene_filter != {}:
+                warnings.warn(
+                    "`lucene_filter` is deprecated. Please use the keyword argument"
+                    " `efficient_filter`"
+                )
+                search_query = _approximate_search_query_with_efficient_filter(
+                    embedding,
+                    lucene_filter,
+                    k=k,
+                    vector_field=vector_field,
+                    score_threshold=score_threshold,
+                )
+            else:
+                search_query = _default_approximate_search_query(
+                    embedding,
+                    k=k,
+                    vector_field=vector_field,
+                    score_threshold=score_threshold,
+                )
+        elif search_type == SCRIPT_SCORING_SEARCH:
+            space_type = kwargs.get("space_type", "l2")
+            pre_filter = kwargs.get("pre_filter", MATCH_ALL_QUERY)
+            search_query = _default_script_query(
+                embedding,
+                k,
+                space_type,
+                pre_filter,
+                vector_field,
+                score_threshold=score_threshold,
+            )
+        elif search_type == PAINLESS_SCRIPTING_SEARCH:
+            space_type = kwargs.get("space_type", "l2Squared")
+            pre_filter = kwargs.get("pre_filter", MATCH_ALL_QUERY)
+            search_query = _default_painless_scripting_query(
+                embedding,
+                k,
+                space_type,
+                pre_filter,
+                vector_field,
+                score_threshold=score_threshold,
+            )
+
+        elif search_type == HYBRID_SEARCH:
+            search_pipeline = kwargs.get("search_pipeline")
+            post_filter = kwargs.get("post_filter", {})
+            query_text = kwargs.get("query_text")
+            path = f"/{index_name}/_search?search_pipeline={search_pipeline}"
+
+            if query_text is None:
+                raise ValueError("query_text must be provided for hybrid search")
+
+            if search_pipeline is None:
+                raise ValueError("search_pipeline must be provided for hybrid search")
+
+            # Async embedding of the query_text
+            embeded_query = await self.embedding_function.aembed_query(query_text)
+
+            # if post filter is provided
+            if post_filter != {}:
+                # hybrid search with post filter
+                payload = _hybrid_search_query_with_post_filter(
+                    query_text, embeded_query, k, post_filter
+                )
+            else:
+                # hybrid search without post filter
+                payload = _default_hybrid_search_query(query_text, embeded_query, k)
+
+            # Async transport request
+            response = await self.async_client.transport.perform_request(
+                method="GET", url=path, body=payload
+            )
+
+            return [hit for hit in response["hits"]["hits"]]
+
+        else:
+            raise ValueError("Invalid `search_type` provided as an argument")
+
+        search_params = {"index": index_name, "body": search_query}
+        if self.routing:
+            search_params["routing"] = self.routing
+
+        # Async search call
+        response = await self.async_client.search(**search_params)
+
+        return [hit for hit in response["hits"]["hits"]]

--- a/libs/community/tests/unit_tests/vectorstores/test_opensearch_vector_search.py
+++ b/libs/community/tests/unit_tests/vectorstores/test_opensearch_vector_search.py
@@ -1,0 +1,354 @@
+from typing import Any, Callable, Dict, List, Tuple
+
+import pytest
+from langchain_core.documents import Document
+from langchain_core.embeddings import Embeddings
+from pytest import MonkeyPatch
+
+from langchain_community.vectorstores.opensearch_vector_search import (
+    HYBRID_SEARCH,
+    OpenSearchVectorSearch,
+)
+
+
+class DummyEmbeddings(Embeddings):
+    def __init__(self, dim: int = 3) -> None:
+        self.dim = dim
+
+    def embed_documents(self, texts: List[str]) -> List[List[float]]:
+        # Return a constant vector per document to keep tests deterministic
+        return [[0.0] * self.dim for _ in texts]
+
+    async def aembed_documents(self, texts: List[str]) -> List[List[float]]:
+        return self.embed_documents(texts)
+
+    def embed_query(self, text: str) -> List[float]:
+        return [1.0] * self.dim
+
+    async def aembed_query(self, text: str) -> List[float]:
+        return self.embed_query(text)
+
+
+class ClientMock:
+    def __init__(self) -> None:
+        self.indices = type(
+            "Indices",
+            (),
+            {
+                "delete": lambda self, index: True,
+                "exists": lambda self, index: False,
+                "create": lambda self, index, body: True,
+                "get": lambda self, index: True,
+                "refresh": lambda self, index: True,
+            },
+        )()
+        self.transport = type(
+            "Transport",
+            (),
+            {
+                "perform_request": lambda self, method, url, body=None, **kwargs: {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_id": "1",
+                                "_score": 0.9,
+                                "_source": {
+                                    "text": "doc",
+                                    "metadata": {"a": 1},
+                                    "vector_field": [0.1, 0.2, 0.3],
+                                },
+                            }
+                        ]
+                    }
+                }
+            },
+        )()
+
+    def search(self, **kwargs: Any) -> Dict[str, Any]:
+        return self.transport.perform_request(
+            method="GET", url="/_search", body=kwargs.get("body")
+        )
+
+    def bulk(self, **kwargs: Any) -> Dict[str, Any]:
+        return {"items": [{"delete": {}}]}
+
+
+class AsyncClientMock:
+    def __init__(self) -> None:
+        # independent async-compatible mock, not inheriting ClientMock
+        # to avoid type override mismatches
+        class ATransport:
+            async def perform_request(
+                self,
+                method: str,
+                url: str,
+                body: Any | None = None,
+                **kwargs: Any,
+            ) -> Dict[str, Any]:
+                return {
+                    "hits": {
+                        "hits": [
+                            {
+                                "_id": "1",
+                                "_score": 0.9,
+                                "_source": {
+                                    "text": "doc",
+                                    "metadata": {"a": 1},
+                                    "vector_field": [0.1, 0.2, 0.3],
+                                },
+                            }
+                        ]
+                    }
+                }
+
+        self.transport = ATransport()
+
+        class AIndices:
+            async def get(self, index: str, **kwargs: Any) -> bool:
+                return True
+
+            async def create(
+                self,
+                index: str,
+                body: Any | None = None,
+                **kwargs: Any,
+            ) -> bool:
+                return True
+
+            async def refresh(self, index: str, **kwargs: Any) -> bool:
+                return True
+
+        self.indices = AIndices()
+
+    async def search(self, **kwargs: Any) -> Dict[str, Any]:
+        return await self.transport.perform_request(
+            method="GET", url="/_search", body=kwargs.get("body")
+        )
+
+
+@pytest.fixture(autouse=True)
+def fake_opensearchpy(monkeypatch: MonkeyPatch) -> None:
+    """Provide a minimal fake opensearchpy to satisfy imports in the vectorstore."""
+    import sys
+    import types
+
+    opensearchpy = types.ModuleType("opensearchpy")
+    exceptions = types.ModuleType("opensearchpy.exceptions")
+
+    class NotFoundError(Exception):
+        pass
+
+    exceptions.NotFoundError = NotFoundError  # type: ignore[attr-defined]
+    helpers = types.ModuleType("opensearchpy.helpers")
+
+    def bulk(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return {"items": []}
+
+    async def async_bulk(*args: Any, **kwargs: Any) -> Dict[str, Any]:
+        return {"items": []}
+
+    helpers.bulk = bulk  # type: ignore[attr-defined]
+    helpers.async_bulk = async_bulk  # type: ignore[attr-defined]
+    opensearchpy.exceptions = exceptions  # type: ignore[attr-defined]
+    opensearchpy.helpers = helpers  # type: ignore[attr-defined]
+    sys.modules["opensearchpy"] = opensearchpy
+    sys.modules["opensearchpy.exceptions"] = exceptions
+    sys.modules["opensearchpy.helpers"] = helpers
+
+
+@pytest.fixture()
+def patch_clients(
+    monkeypatch: MonkeyPatch,
+) -> Callable[[], Tuple[ClientMock, AsyncClientMock]]:
+    def _patch(
+        url: str = "http://localhost:9200",
+    ) -> Tuple[ClientMock, AsyncClientMock]:
+        client = ClientMock()
+        async_client = AsyncClientMock()
+        monkeypatch.setattr(
+            "langchain_community.vectorstores.opensearch_vector_search._get_opensearch_client",
+            lambda opensearch_url, **kwargs: client,
+        )
+        monkeypatch.setattr(
+            "langchain_community.vectorstores.opensearch_vector_search._get_async_opensearch_client",
+            lambda opensearch_url, **kwargs: async_client,
+        )
+        return client, async_client
+
+    return _patch
+
+
+def test_add_texts_and_similarity_search_basic(
+    patch_clients: Callable[[], Tuple[ClientMock, AsyncClientMock]],
+) -> None:
+    patch_clients()
+    embed = DummyEmbeddings(dim=3)
+    vs = OpenSearchVectorSearch(
+        opensearch_url="http://localhost:9200",
+        index_name="test-index",
+        embedding_function=embed,
+        engine="nmslib",
+    )
+
+    ids = vs.add_texts(
+        ["hola", "adios"], metadatas=[{"k": "v"}, {"x": 1}], ids=["id1", "id2"]
+    )
+    assert len(ids) == 2
+
+    docs = vs.similarity_search("hola", k=1)
+    assert isinstance(docs[0], Document)
+    assert docs[0].page_content == "doc"
+
+
+def test_similarity_search_with_score_by_vector_builds_query(
+    patch_clients: Callable[[], Tuple[ClientMock, AsyncClientMock]],
+) -> None:
+    patch_clients()
+    embed = DummyEmbeddings(dim=3)
+    vs = OpenSearchVectorSearch(
+        opensearch_url="http://localhost:9200",
+        index_name="test-index",
+        embedding_function=embed,
+        engine="nmslib",
+    )
+
+    vec = [0.1, 0.2, 0.3]
+    hits = vs._raw_similarity_search_with_score_by_vector(
+        vec, k=2, search_type="approximate_search"
+    )
+    # ensure search invoked and returns hits
+    assert isinstance(hits, list)
+    assert hits and "_id" in hits[0]
+
+
+def test_boolean_vs_efficient_filter_exclusive(
+    patch_clients: Callable[[], Tuple[ClientMock, AsyncClientMock]],
+) -> None:
+    patch_clients()
+    embed = DummyEmbeddings(dim=3)
+    vs = OpenSearchVectorSearch("http://localhost:9200", "idx", embed)
+    vec = [0.1, 0.2, 0.3]
+    with pytest.raises(ValueError):
+        vs._raw_similarity_search_with_score_by_vector(
+            vec,
+            k=2,
+            search_type="approximate_search",
+            boolean_filter={"term": {"x": 1}},
+            efficient_filter={"term": {"y": 2}},
+        )
+
+
+def test_delete_requires_ids(
+    patch_clients: Callable[[], Tuple[ClientMock, AsyncClientMock]],
+) -> None:
+    patch_clients()
+    vs = OpenSearchVectorSearch("http://localhost:9200", "idx", DummyEmbeddings())
+    with pytest.raises(ValueError):
+        vs.delete(ids=None)
+
+
+def test_index_exists_false(
+    patch_clients: Callable[[], Tuple[ClientMock, AsyncClientMock]],
+) -> None:
+    client, _ = patch_clients()
+    vs = OpenSearchVectorSearch("http://localhost:9200", "idx", DummyEmbeddings())
+    assert vs.index_exists("idx") is False
+
+
+def test_create_index_appx_mapping_and_duplicate(
+    patch_clients: Callable[[], Tuple[ClientMock, AsyncClientMock]],
+    monkeypatch: MonkeyPatch,
+) -> None:
+    client, _ = patch_clients()
+    # make indices.exists return True to trigger error
+    monkeypatch.setattr(client.indices, "exists", lambda index: True)
+    vs = OpenSearchVectorSearch(
+        "http://localhost:9200", "idx", DummyEmbeddings(), engine="nmslib"
+    )
+    with pytest.raises(RuntimeError):
+        vs.create_index(dimension=3, index_name="idx")
+
+
+def test_hybrid_search_requires_pipeline_and_text(
+    patch_clients: Callable[[], Tuple[ClientMock, AsyncClientMock]],
+) -> None:
+    patch_clients()
+    vs = OpenSearchVectorSearch("http://localhost:9200", "idx", DummyEmbeddings())
+    with pytest.raises(ValueError):
+        vs._raw_similarity_search_with_score_by_vector(
+            [0.1, 0.2, 0.3], k=2, search_type=HYBRID_SEARCH, search_pipeline="pipe"
+        )
+    with pytest.raises(ValueError):
+        vs._raw_similarity_search_with_score_by_vector(
+            [0.1, 0.2, 0.3], k=2, search_type=HYBRID_SEARCH, query_text="hola"
+        )
+
+
+@pytest.mark.asyncio
+async def test_async_similarity_search_with_score(
+    patch_clients: Callable[[], Tuple[ClientMock, AsyncClientMock]],
+) -> None:
+    patch_clients()
+    vs = OpenSearchVectorSearch("http://localhost:9200", "idx", DummyEmbeddings())
+    docs_scores = await vs.asimilarity_search_with_score("hola", k=1)
+    assert len(docs_scores) == 1
+    doc, score = docs_scores[0]
+    assert isinstance(doc, Document)
+    assert isinstance(score, float)
+
+
+@pytest.mark.asyncio
+async def test_adelete_requires_ids(
+    patch_clients: Callable[[], Tuple[ClientMock, AsyncClientMock]],
+) -> None:
+    patch_clients()
+    vs = OpenSearchVectorSearch("http://localhost:9200", "idx", DummyEmbeddings())
+    with pytest.raises(ValueError):
+        await vs.adelete(ids=None)
+
+
+def test_hits_to_documents_metadata_variants(
+    patch_clients: Callable[[], Tuple[ClientMock, AsyncClientMock]],
+) -> None:
+    patch_clients()
+    vs = OpenSearchVectorSearch("http://localhost:9200", "idx", DummyEmbeddings())
+    hits = [
+        {
+            "_id": "x",
+            "_score": 0.5,
+            "_source": {"text": "t", "metadata": {"a": 1}, "other": {"b": 2}},
+        }
+    ]
+    docs_scores = vs._hits_to_documents(hits, text_field="text", metadata_field="*")
+    assert docs_scores[0][0].metadata.get("metadata") == {"a": 1}
+    docs_scores = vs._hits_to_documents(
+        hits, text_field="text", metadata_field="metadata"
+    )
+    assert docs_scores[0][0].metadata == {"a": 1}
+
+
+def test_from_texts_uses_env(
+    monkeypatch: MonkeyPatch,
+    patch_clients: Callable[[], Tuple[ClientMock, AsyncClientMock]],
+) -> None:
+    patch_clients()
+    monkeypatch.setenv("OPENSEARCH_URL", "http://localhost:9200")
+    monkeypatch.setenv("OPENSEARCH_INDEX_NAME", "env-index")
+    embed = DummyEmbeddings(dim=3)
+    vs = OpenSearchVectorSearch.from_texts(["a", "b"], embed)
+    assert isinstance(vs, OpenSearchVectorSearch)
+    assert vs.index_name == "env-index"
+
+
+@pytest.mark.asyncio
+async def test_afrom_texts(
+    monkeypatch: MonkeyPatch,
+    patch_clients: Callable[[], Tuple[ClientMock, AsyncClientMock]],
+) -> None:
+    patch_clients()
+    monkeypatch.setenv("OPENSEARCH_URL", "http://localhost:9200")
+    monkeypatch.setenv("OPENSEARCH_INDEX_NAME", "env-index")
+    embed = DummyEmbeddings(dim=3)
+    vs = await OpenSearchVectorSearch.afrom_texts(["a", "b"], embed)
+    assert isinstance(vs, OpenSearchVectorSearch)
+    assert vs.index_name == "env-index"


### PR DESCRIPTION
**PR Title:**
`feat(community): add native async support to OpenSearchVectorSearch`

**PR Message:**

**Description:**
This PR implements native asynchronous support for the `OpenSearchVectorSearch` vector store in `langchain-community`, replacing the default `run_in_executor` workaround with true non-blocking calls using the `AsyncOpenSearch` client.

**Key changes:**

* Implemented `asimilarity_search`, `asimilarity_search_with_score`, and `asimilarity_search_with_score_by_vector` using `self.async_client`.
* Added `_araw_similarity_search_with_score_by_vector` to handle the low-level async API calls, maintaining feature parity with the synchronous version (including `hybrid_search`, `script_scoring`, `painless_scripting`, and `routing` support).
* Refactored the response parsing logic into a new private helper method `_hits_to_documents` to reuse code between sync and async implementations (DRY).
* Fixed an issue where `routing` parameters might be ignored in async contexts.

**Issue:**
N/A

**Dependencies:**
No new dependencies (relies on existing `opensearch-py`).

* [x] **Lint and test**: I have run `make format`, `make lint` and `make test` from the root of the package(s).