### PR TITLE
feat(duckdb): add duckdb custom_user_agent

### DIFF
--- a/libs/community/langchain_community/document_loaders/duckdb_loader.py
+++ b/libs/community/langchain_community/document_loaders/duckdb_loader.py
@@ -3,6 +3,7 @@ from typing import Dict, List, Optional, cast
 from langchain_core.documents import Document
 
 from langchain_community.document_loaders.base import BaseLoader
+from langchain_community.utilities.sql_database import _inject_langchain_user_agent
 
 
 class DuckDBLoader(BaseLoader):
@@ -54,8 +55,9 @@ class DuckDBLoader(BaseLoader):
             )
 
         docs = []
+        config = _inject_langchain_user_agent(self.config)
         with duckdb.connect(
-            database=self.database, read_only=self.read_only, config=self.config
+            database=self.database, read_only=self.read_only, config=config
         ) as con:
             query_result = con.execute(self.query)
             results = query_result.fetchall()

--- a/libs/community/langchain_community/utilities/sql_database.py
+++ b/libs/community/langchain_community/utilities/sql_database.py
@@ -48,6 +48,25 @@ def _patch_duckdb_types() -> None:
 _patch_duckdb_types()
 
 
+def _inject_langchain_user_agent(config: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+    """Add 'langchain' to DuckDB custom_user_agent config."""
+    config = dict(config or {})
+    existing = config.get("custom_user_agent", "")
+    config["custom_user_agent"] = f"langchain {existing}" if existing else "langchain"
+
+    return config
+
+
+def _add_duckdb_user_agent(engine_args: dict) -> dict:
+    """Add langchain user agent to SQLAlchemy engine_args for DuckDB."""
+    engine_args = dict(engine_args or {})
+    connect_args = engine_args.get("connect_args", {})
+    connect_args = connect_args.copy()
+    connect_args["config"] = _inject_langchain_user_agent(connect_args.get("config"))
+    engine_args["connect_args"] = connect_args
+    return engine_args
+
+
 def _format_index(index: sqlalchemy.engine.interfaces.ReflectedIndex) -> str:
     return (
         f"Name: {index['name']}, Unique: {index['unique']},"
@@ -177,6 +196,12 @@ class SQLDatabase:
     ) -> SQLDatabase:
         """Construct a SQLAlchemy engine from URI."""
         _engine_args = engine_args or {}
+
+        # Add LangChain user agent for DuckDB/MotherDuck connections
+        uri_str = str(database_uri)
+        if uri_str.startswith("duckdb://"):
+            _engine_args = _add_duckdb_user_agent(_engine_args)
+
         return cls(create_engine(database_uri, **_engine_args), **kwargs)
 
     @classmethod

--- a/libs/community/tests/integration_tests/document_loaders/test_duckdb.py
+++ b/libs/community/tests/integration_tests/document_loaders/test_duckdb.py
@@ -54,3 +54,27 @@ def test_duckdb_loader_metadata_columns() -> None:
     assert len(docs) == 1
     assert docs[0].page_content == "a: 1"
     assert docs[0].metadata == {"b": 2}
+
+
+@unittest.skipIf(not duckdb_installed, "duckdb not installed")
+def test_duckdb_loader_user_agent() -> None:
+    """Test that DuckDBLoader injects langchain user agent."""
+    loader = DuckDBLoader("SELECT current_setting('custom_user_agent') as ua")
+    docs = loader.load()
+
+    assert len(docs) == 1
+    assert "langchain" in docs[0].page_content
+
+
+@unittest.skipIf(not duckdb_installed, "duckdb not installed")
+def test_duckdb_loader_user_agent_preserves_user_config() -> None:
+    """Test that DuckDBLoader preserves user-provided config and prepends langchain."""
+    loader = DuckDBLoader(
+        "SELECT current_setting('custom_user_agent') as ua",
+        config={"custom_user_agent": "my-app"},
+    )
+    docs = loader.load()
+
+    assert len(docs) == 1
+    # langchain should come first, followed by user's value
+    assert "langchain my-app" in docs[0].page_content

--- a/libs/community/tests/unit_tests/test_sql_database.py
+++ b/libs/community/tests/unit_tests/test_sql_database.py
@@ -18,6 +18,8 @@ from sqlalchemy.engine import Engine, Result
 
 from langchain_community.utilities.sql_database import (
     SQLDatabase,
+    _add_duckdb_user_agent,
+    _inject_langchain_user_agent,
     sanitize_schema,
     truncate_word,
 )
@@ -288,3 +290,61 @@ def test_sanitize_schema() -> None:
         with pytest.raises(ValueError) as ex:
             sanitize_schema(schema)
         assert f"Schema name '{schema}' contains invalid characters" in str(ex.value)
+
+
+def test_inject_langchain_user_agent() -> None:
+    """Test that _inject_langchain_user_agent adds langchain to config."""
+    # None config should return dict with user agent
+    result = _inject_langchain_user_agent(None)
+    assert result == {"custom_user_agent": "langchain"}
+
+    # Empty config should get user agent added
+    result = _inject_langchain_user_agent({})
+    assert result == {"custom_user_agent": "langchain"}
+
+    # Existing config should be preserved
+    result = _inject_langchain_user_agent({"threads": 4})
+    assert result == {"threads": 4, "custom_user_agent": "langchain"}
+
+    # User-provided custom_user_agent should have langchain prepended
+    result = _inject_langchain_user_agent({"custom_user_agent": "my-app"})
+    assert result == {"custom_user_agent": "langchain my-app"}
+
+    # Original dict should not be mutated
+    original = {"threads": 4}
+    _inject_langchain_user_agent(original)
+    assert original == {"threads": 4}
+
+
+def test_add_duckdb_user_agent() -> None:
+    """Test that _add_duckdb_user_agent adds langchain user agent."""
+    # Empty engine_args should get user agent added
+    result = _add_duckdb_user_agent({})
+    assert result == {"connect_args": {"config": {"custom_user_agent": "langchain"}}}
+
+    # Existing connect_args should be preserved
+    result = _add_duckdb_user_agent({"connect_args": {"timeout": 30}})
+    assert result == {
+        "connect_args": {"timeout": 30, "config": {"custom_user_agent": "langchain"}}
+    }
+
+    # Existing config should be preserved
+    result = _add_duckdb_user_agent(
+        {"connect_args": {"config": {"threads": 4}}}
+    )
+    assert result == {
+        "connect_args": {"config": {"threads": 4, "custom_user_agent": "langchain"}}
+    }
+
+    # User-provided custom_user_agent should have langchain prepended
+    result = _add_duckdb_user_agent(
+        {"connect_args": {"config": {"custom_user_agent": "my-app"}}}
+    )
+    assert result == {
+        "connect_args": {"config": {"custom_user_agent": "langchain my-app"}}
+    }
+
+    # Original dict should not be mutated
+    original = {"connect_args": {"config": {"threads": 4}}}
+    _add_duckdb_user_agent(original)
+    assert original == {"connect_args": {"config": {"threads": 4}}}


### PR DESCRIPTION
DuckDB has a `custom_user_agent` field that is used by hosted services like MotherDuck to identify the integration (python), framework (SQLAlchemy or none, depending on whether the loader is used) and the integration (LangChain!).

This PR adds the `langchain` identifier to 2 out of the 3 DuckDB paths. The vectorstore was impractical to add it to, since it expects the end user to create the DuckDB connection first. It might be more ergonomic to have the user pass the connection string, but that's a side quest for a different Christmas.

Adding conditional logic to `sql_database.py` is not ideal -- should I create a helper like `from_cnosdb()` instead?
 

- [x] **Lint and test**: 6 tests in `tests/unit_tests/document_loaders/test_recursive_url_loader.py` fail for me. These seem unrelated to my changes; let's see what CI says.

Gen AI disclaimer: I use Claude Code to generate the first iteration, then pair program with it until the code meets my intent and standards. I am responsible for every line of code proposed.
