### PR TITLE
fix(community): add args schema to JiraAction tool

### DIFF
--- a/libs/community/langchain_community/tools/jira/tool.py
+++ b/libs/community/langchain_community/tools/jira/tool.py
@@ -20,13 +20,25 @@ toolkit = JiraToolkit.from_jira_api_wrapper(jira)
 ```
 """
 
-from typing import Optional
+from typing import Optional, Type
 
 from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools import BaseTool
-from pydantic import Field
+from pydantic import BaseModel, Field
 
 from langchain_community.utilities.jira import JiraAPIWrapper
+
+
+class JiraActionInput(BaseModel):
+    """Input schema for Jira actions."""
+
+    instructions: str = Field(
+        ...,
+        description=(
+            "Instructions for the Jira action. Provide a JQL query, issue fields "
+            "JSON, or other Jira API input based on the tool description."
+        ),
+    )
 
 
 class JiraAction(BaseTool):
@@ -36,6 +48,7 @@ class JiraAction(BaseTool):
     mode: str
     name: str = ""
     description: str = ""
+    args_schema: Type[BaseModel] = JiraActionInput
 
     def _run(
         self,

--- a/libs/community/tests/unit_tests/tools/jira/test_jira_tool.py
+++ b/libs/community/tests/unit_tests/tools/jira/test_jira_tool.py
@@ -1,0 +1,39 @@
+from unittest.mock import MagicMock
+
+import pytest
+from pydantic import ValidationError
+
+from langchain_community.tools.jira.tool import JiraAction
+
+
+def test_jira_tool_invocation_validates_input() -> None:
+    """Test that JiraAction invokes api_wrapper with mode and instructions."""
+    api_wrapper = MagicMock()
+    api_wrapper.run.return_value = "ok"
+    # Use model_construct to bypass JiraAPIWrapper validation
+    tool = JiraAction.model_construct(
+        name="jql_query",
+        description="JQL search",
+        mode="jql",
+        api_wrapper=api_wrapper,
+    )
+
+    result = tool.invoke({"instructions": "assignee = currentUser()"})
+
+    assert result == "ok"
+    api_wrapper.run.assert_called_once_with("jql", "assignee = currentUser()")
+
+
+def test_jira_tool_invocation_raises_validation_error() -> None:
+    """Test that invoking JiraAction with wrong input key raises ValidationError."""
+    api_wrapper = MagicMock()
+    # Use model_construct to bypass JiraAPIWrapper validation
+    tool = JiraAction.model_construct(
+        name="jql_query",
+        description="JQL search",
+        mode="jql",
+        api_wrapper=api_wrapper,
+    )
+
+    with pytest.raises(ValidationError):
+        tool.invoke({"query": "assignee = currentUser()"})


### PR DESCRIPTION
**Description**
Adds a Pydantic input schema (`JiraActionInput`) to the `JiraAction` tool so that:
- The `instructions` argument is explicitly defined with a clear description
- `invoke()` performs proper validation and raises `ValidationError` for invalid inputs
- Tool metadata is improved for better agent prompting
- Added unit tests covering both valid invocation and validation error cases

**Issue**
#490 

**Dependencies**
None




