### PR TITLE
fix(community): handle dirty data crash in SQLDatabase sample rows

### DIFF
--- a/libs/community/langchain_community/utilities/sql_database.py
+++ b/libs/community/langchain_community/utilities/sql_database.py
@@ -461,9 +461,9 @@ class SQLDatabase:
             # save the sample rows in string format
             sample_rows_str = "\n".join(["\t".join(row) for row in sample_rows])
 
-        # in some dialects when there are no rows in the table a
-        # 'ProgrammingError' is returned
-        except ProgrammingError:
+        # Catching ProgrammingError to handle specific dialect errors (original behavior)
+        # Catching ValueError to handle Python-level type conversion errors (e.g. invalid dates in DB)
+        except (ProgrammingError, ValueError):
             sample_rows_str = ""
 
         return (


### PR DESCRIPTION
**Description:**
This PR fixes a crash in `SQLDatabase._get_sample_rows` when the database contains "dirty data" that fails type coercion (e.g., invalid date strings in a DATE column). 

Previously, the code only caught `sqlalchemy.exc.ProgrammingError`, which meant that `ValueError` raised by SQLAlchemy's processors during data fetching would bubble up and cause the entire `get_table_info()` method to fail. This made the SQL tool unusable for agents even if the table schema was valid.

The fix extends the exception handling to catch `ValueError` alongside `ProgrammingError`, ensuring that sample row fetching degrades gracefully (returning an empty string) rather than crashing the application.

**Traceback:**
```python
  File "langchain_community/utilities/sql_database.py", line 452, in _get_sample_rows
      sample_rows = list(
    File "sqlalchemy/engine/result.py", line 529, in iterrows
      make_row(raw_row) if make_row else raw_row
    ...
    File "sqlalchemy/cyextension/processors.pyx", line 51, in sqlalchemy.cyextension.processors.str_to_date
  ValueError: Invalid isoformat string: '04/12/2005 09:30'
```

**Issue:**
N/A (Fixes a potential crash discovered during usage)

**Dependencies:**
None