### PR TITLE
community: Add Unbias crypto sentiment tool

### DIFF
--- a/libs/community/langchain_community/tools/__init__.py
+++ b/libs/community/langchain_community/tools/__init__.py
@@ -317,6 +317,9 @@ if TYPE_CHECKING:
         TavilyAnswer,
         TavilySearchResults,
     )
+    from langchain_community.tools.unbias import (
+        UnbiasCryptoSentiment,
+    )
     from langchain_community.tools.vectorstore.tool import (
         VectorStoreQATool,
         VectorStoreQAWithSourcesTool,
@@ -482,6 +485,7 @@ __all__ = [
     "SteamshipImageGenerationTool",
     "TavilyAnswer",
     "TavilySearchResults",
+    "UnbiasCryptoSentiment",
     "VectorStoreQATool",
     "VectorStoreQAWithSourcesTool",
     "WikipediaQueryRun",
@@ -638,6 +642,7 @@ _module_lookup = {
     "StructuredTool": "langchain_core.tools",
     "TavilyAnswer": "langchain_community.tools.tavily_search",
     "TavilySearchResults": "langchain_community.tools.tavily_search",
+    "UnbiasCryptoSentiment": "langchain_community.tools.unbias",
     "Tool": "langchain_core.tools",
     "VectorStoreQATool": "langchain_community.tools.vectorstore.tool",
     "VectorStoreQAWithSourcesTool": "langchain_community.tools.vectorstore.tool",

--- a/libs/community/langchain_community/tools/unbias/__init__.py
+++ b/libs/community/langchain_community/tools/unbias/__init__.py
@@ -1,0 +1,7 @@
+"""Unbias Crypto Sentiment Tool."""
+
+from langchain_community.tools.unbias.tool import (
+    UnbiasCryptoSentiment,
+)
+
+__all__ = ["UnbiasCryptoSentiment"]

--- a/libs/community/langchain_community/tools/unbias/tool.py
+++ b/libs/community/langchain_community/tools/unbias/tool.py
@@ -1,0 +1,166 @@
+"""Tool for querying Unbias crypto sentiment API."""
+
+from typing import Optional, Type
+
+import requests
+from langchain_core.callbacks import CallbackManagerForToolRun
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+
+class UnbiasInput(BaseModel):
+    """Input for the Unbias crypto sentiment tool."""
+
+    asset: str = Field(
+        default="BTC",
+        description="Cryptocurrency asset symbol. Supported: BTC, ETH",
+    )
+    days: int = Field(
+        default=7,
+        description="Number of days of historical data (1-365)",
+    )
+
+
+class UnbiasCryptoSentiment(BaseTool):
+    """Tool for getting crypto market sentiment from Unbias.
+
+    Unbias aggregates sentiment from 100+ professional crypto analysts
+    and traders on Twitter/X, providing real-time market consensus data.
+
+    Setup:
+        Get an API key at https://unbias.fyi/api
+
+        .. code-block:: bash
+
+            export UNBIAS_API_KEY="your-api-key"
+
+    Usage:
+        .. code-block:: python
+
+            from langchain_community.tools.unbias import UnbiasCryptoSentiment
+
+            tool = UnbiasCryptoSentiment(api_key="your-api-key")
+            result = tool.invoke({"asset": "BTC", "days": 7})
+            print(result)
+    """
+
+    name: str = "unbias_crypto_sentiment"
+    description: str = (
+        "Get real-time crypto market sentiment from 100+ professional analysts. "
+        "Use this tool when you need to know if analysts are bullish or bearish "
+        "on Bitcoin (BTC) or Ethereum (ETH), or to get market consensus data. "
+        "Returns consensus index (-100 to +100), analyst counts, and sentiment trends."
+    )
+    args_schema: Type[BaseModel] = UnbiasInput
+
+    api_key: str = Field(description="Unbias API key")
+    api_base: str = Field(
+        default="https://unbias.fyi/api/v1",
+        description="Unbias API base URL",
+    )
+
+    def _format_response(self, data: dict) -> str:
+        """Format the API response into a readable string."""
+        if "data" in data and data["data"]:
+            # Historical data
+            latest = data["data"][-1]
+            period = data.get("period", {})
+
+            lines = [
+                f"## {data['asset']} Market Sentiment",
+                f"Period: {period.get('start', 'N/A')} to {period.get('end', 'N/A')}",
+                f"Data points: {data.get('count', len(data['data']))}",
+                "",
+                f"### Latest ({latest['date']})",
+                f"- Consensus Index: {latest['consensus_index']:.1f} (-100 to +100)",
+                f"- 30-Day MA: {latest['consensus_index_30d_ma']:.1f}",
+            ]
+
+            if latest.get("avg_sentiment_score") is not None:
+                lines.append(
+                    f"- Avg Sentiment Score: {latest['avg_sentiment_score']:.1f}/100"
+                )
+
+            lines.extend(
+                [
+                    f"- Bullish Analysts: {latest['bullish_analysts']}",
+                    f"- Bearish Analysts: {latest['bearish_analysts']}",
+                    f"- Total Analysts: {latest['total_analysts']}",
+                ]
+            )
+
+            # Calculate trend
+            if len(data["data"]) > 1:
+                oldest = data["data"][0]
+                change = latest["consensus_index"] - oldest["consensus_index"]
+                trend = "↑" if change > 0 else "↓" if change < 0 else "→"
+                lines.extend(
+                    [
+                        "",
+                        "### Trend",
+                        f"- {len(data['data'])}-day change: {trend} {change:+.1f} points",
+                    ]
+                )
+
+            return "\n".join(lines)
+        else:
+            # Single data point
+            lines = [
+                f"## {data['asset']} Market Sentiment (Latest)",
+                f"Date: {data.get('date', 'N/A')}",
+                f"- Consensus Index: {data.get('consensus_index', 0):.1f} (-100 to +100)",
+                f"- 30-Day MA: {data.get('consensus_index_30d_ma', 0):.1f}",
+            ]
+
+            if data.get("avg_sentiment_score") is not None:
+                lines.append(
+                    f"- Avg Sentiment Score: {data['avg_sentiment_score']:.1f}/100"
+                )
+
+            lines.extend(
+                [
+                    f"- Bullish Analysts: {data.get('bullish_analysts', 0)}",
+                    f"- Bearish Analysts: {data.get('bearish_analysts', 0)}",
+                    f"- Total Analysts: {data.get('total_analysts', 0)}",
+                ]
+            )
+
+            return "\n".join(lines)
+
+    def _run(
+        self,
+        asset: str = "BTC",
+        days: int = 7,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Execute the tool to get crypto sentiment data.
+
+        Args:
+            asset: Cryptocurrency symbol (BTC or ETH)
+            days: Number of days of historical data
+
+        Returns:
+            Formatted string with sentiment data
+        """
+        try:
+            response = requests.get(
+                f"{self.api_base}/consensus",
+                params={
+                    "api_key": self.api_key,
+                    "asset": asset.upper(),
+                    "days": days,
+                },
+                timeout=30,
+            )
+            response.raise_for_status()
+            data = response.json()
+
+            if "error" in data:
+                return f"API Error: {data['error']}"
+
+            return self._format_response(data)
+
+        except requests.exceptions.RequestException as e:
+            return f"Error fetching sentiment data: {str(e)}"
+        except Exception as e:
+            return f"Unexpected error: {str(e)}"

--- a/libs/community/tests/unit_tests/tools/test_unbias.py
+++ b/libs/community/tests/unit_tests/tools/test_unbias.py
@@ -1,0 +1,100 @@
+"""Tests for Unbias crypto sentiment tool."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from langchain_community.tools.unbias import UnbiasCryptoSentiment
+
+
+@pytest.fixture
+def mock_response_data():
+    """Sample API response data."""
+    return {
+        "asset": "BTC",
+        "period": {"start": "2024-01-01", "end": "2024-01-07"},
+        "granularity": "daily",
+        "count": 7,
+        "data": [
+            {
+                "date": "2024-01-01",
+                "consensus_index": 15.0,
+                "consensus_index_30d_ma": 10.0,
+                "avg_sentiment_score": 58.5,
+                "bullish_analysts": 70,
+                "bearish_analysts": 35,
+                "total_analysts": 105,
+            },
+            {
+                "date": "2024-01-07",
+                "consensus_index": 20.0,
+                "consensus_index_30d_ma": 12.0,
+                "avg_sentiment_score": 62.0,
+                "bullish_analysts": 75,
+                "bearish_analysts": 36,
+                "total_analysts": 111,
+            },
+        ],
+    }
+
+
+def test_unbias_tool_initialization():
+    """Test tool can be initialized with API key."""
+    tool = UnbiasCryptoSentiment(api_key="test-key")
+    assert tool.name == "unbias_crypto_sentiment"
+    assert tool.api_key == "test-key"
+    assert "crypto" in tool.description.lower()
+    assert "sentiment" in tool.description.lower()
+
+
+def test_unbias_tool_description():
+    """Test tool description contains key information."""
+    tool = UnbiasCryptoSentiment(api_key="test-key")
+    assert "bullish" in tool.description.lower()
+    assert "bearish" in tool.description.lower()
+    assert "analyst" in tool.description.lower()
+
+
+@patch("langchain_community.tools.unbias.tool.requests.get")
+def test_unbias_tool_run(mock_get, mock_response_data):
+    """Test tool execution with mocked API response."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = mock_response_data
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    tool = UnbiasCryptoSentiment(api_key="test-key")
+    result = tool._run(asset="BTC", days=7)
+
+    assert "BTC" in result
+    assert "Consensus Index" in result
+    assert "Bullish" in result
+    assert "Bearish" in result
+    mock_get.assert_called_once()
+
+
+@patch("langchain_community.tools.unbias.tool.requests.get")
+def test_unbias_tool_handles_error(mock_get):
+    """Test tool handles API errors gracefully."""
+    mock_get.side_effect = Exception("API connection failed")
+
+    tool = UnbiasCryptoSentiment(api_key="test-key")
+    result = tool._run(asset="BTC", days=7)
+
+    assert "error" in result.lower()
+
+
+@patch("langchain_community.tools.unbias.tool.requests.get")
+def test_unbias_tool_formats_trend(mock_get, mock_response_data):
+    """Test that trend calculation is included in output."""
+    mock_response = MagicMock()
+    mock_response.json.return_value = mock_response_data
+    mock_response.raise_for_status = MagicMock()
+    mock_get.return_value = mock_response
+
+    tool = UnbiasCryptoSentiment(api_key="test-key")
+    result = tool._run(asset="BTC", days=7)
+
+    assert "Trend" in result
+    assert "↑" in result  # Price went up from 15 to 20


### PR DESCRIPTION
# Add Unbias Crypto Sentiment Tool

## Description

This PR adds a new tool for querying crypto market sentiment data from [Unbias](https://unbias.fyi).

**What is Unbias?**
Unbias aggregates sentiment from 100+ professional crypto analysts and traders on Twitter/X, providing real-time market consensus data including:
- Consensus Index (-100 to +100)
- Bullish/Bearish analyst counts
- Average sentiment scores
- Historical trends with moving averages

**Why add this tool?**
- Crypto sentiment is a common query for AI agents building trading bots or market analysis tools
- No existing LangChain tool provides professional analyst sentiment data
- Unbias tracks verified professional analysts (not retail social media)

## Usage Example

```python
from langchain_community.tools.unbias import UnbiasCryptoSentiment

tool = UnbiasCryptoSentiment(api_key="your-api-key")
result = tool.invoke({"asset": "BTC", "days": 7})
```

## Files Changed

- `libs/community/langchain_community/tools/unbias/__init__.py` - Module exports
- `libs/community/langchain_community/tools/unbias/tool.py` - Main tool implementation
- `libs/community/tests/unit_tests/tools/test_unbias.py` - Unit tests
- `docs/docs/integrations/tools/unbias.md` - Documentation

## Checklist

- [x] Added unit tests
- [x] Added documentation
- [x] Follows existing tool patterns (similar to OpenWeatherMap, Tavily)
- [x] No breaking changes
- [x] API key is required (not hardcoded)

## API Information

- **Website**: https://unbias.fyi
- **API Docs**: https://unbias.fyi/docs/api
- **Free tier**: Latest data point, 100 req/day
- **Pro tier**: Full historical data, unlimited requests

## Related Links

- [Unbias MCP Server](https://www.npmjs.com/package/unbias-mcp-server) (npm)
- [llms.txt](https://unbias.fyi/llms.txt)