### PR TITLE
fix(document_loaders): add null checks in HNLoader to prevent AttributeError

### DIFF
--- a/libs/community/langchain_community/document_loaders/hn.py
+++ b/libs/community/langchain_community/document_loaders/hn.py
@@ -31,7 +31,8 @@ class HNLoader(WebBaseLoader):
     def load_comments(self, soup_info: Any) -> List[Document]:
         """Load comments from a HN post."""
         comments = soup_info.select("tr[class='athing comtr']")
-        title = soup_info.select_one("tr[id='pagespace']").get("title")
+        pagespace = soup_info.select_one("tr[id='pagespace']")
+        title = pagespace.get("title") if pagespace else None
         return [
             Document(
                 page_content=comment.text.strip(),
@@ -45,9 +46,16 @@ class HNLoader(WebBaseLoader):
         items = soup.select("tr[class='athing']")
         documents = []
         for lineItem in items:
-            ranking = lineItem.select_one("span[class='rank']").text
-            link = lineItem.find("span", {"class": "titleline"}).find("a").get("href")
-            title = lineItem.find("span", {"class": "titleline"}).text.strip()
+            rank_elem = lineItem.select_one("span[class='rank']")
+            ranking = rank_elem.text if rank_elem else None
+            titleline = lineItem.find("span", {"class": "titleline"})
+            if titleline:
+                link_elem = titleline.find("a")
+                link = link_elem.get("href") if link_elem else None
+                title = titleline.text.strip()
+            else:
+                link = None
+                title = None
             metadata = {
                 "source": self.web_path,
                 "title": title,
@@ -56,7 +64,10 @@ class HNLoader(WebBaseLoader):
             }
             documents.append(
                 Document(
-                    page_content=title, link=link, ranking=ranking, metadata=metadata
+                    page_content=title or "",
+                    link=link,
+                    ranking=ranking,
+                    metadata=metadata,
                 )
             )
         return documents

--- a/libs/community/tests/unit_tests/document_loaders/test_hn.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_hn.py
@@ -1,0 +1,119 @@
+"""Unit tests for HNLoader."""
+
+from unittest.mock import MagicMock
+
+from langchain_community.document_loaders.hn import HNLoader
+
+
+class TestHNLoader:
+    """Tests for HNLoader."""
+
+    def test_load_comments_with_valid_pagespace(self) -> None:
+        """Test load_comments when pagespace element exists."""
+        loader = HNLoader("https://news.ycombinator.com/item?id=12345")
+
+        # Create mock soup with valid structure
+        mock_soup = MagicMock()
+        mock_comment = MagicMock()
+        mock_comment.text.strip.return_value = "This is a comment"
+        mock_soup.select.return_value = [mock_comment]
+
+        mock_pagespace = MagicMock()
+        mock_pagespace.get.return_value = "Test Title"
+        mock_soup.select_one.return_value = mock_pagespace
+
+        docs = loader.load_comments(mock_soup)
+
+        assert len(docs) == 1
+        assert docs[0].page_content == "This is a comment"
+        assert docs[0].metadata["title"] == "Test Title"
+
+    def test_load_comments_with_missing_pagespace(self) -> None:
+        """Test load_comments when pagespace element is missing (bug fix for #494)."""
+        loader = HNLoader("https://news.ycombinator.com/item?id=12345")
+
+        # Create mock soup where pagespace is None
+        mock_soup = MagicMock()
+        mock_comment = MagicMock()
+        mock_comment.text.strip.return_value = "This is a comment"
+        mock_soup.select.return_value = [mock_comment]
+        mock_soup.select_one.return_value = None  # pagespace not found
+
+        # This should NOT raise AttributeError anymore
+        docs = loader.load_comments(mock_soup)
+
+        assert len(docs) == 1
+        assert docs[0].page_content == "This is a comment"
+        assert docs[0].metadata["title"] is None
+
+    def test_load_comments_with_empty_comments(self) -> None:
+        """Test load_comments when no comments are found."""
+        loader = HNLoader("https://news.ycombinator.com/item?id=12345")
+
+        mock_soup = MagicMock()
+        mock_soup.select.return_value = []
+        mock_soup.select_one.return_value = None
+
+        docs = loader.load_comments(mock_soup)
+
+        assert len(docs) == 0
+
+    def test_load_results_with_valid_items(self) -> None:
+        """Test load_results when items have valid structure."""
+        loader = HNLoader("https://news.ycombinator.com/")
+
+        mock_soup = MagicMock()
+
+        # Create a mock item with valid structure
+        mock_item = MagicMock()
+        mock_rank = MagicMock()
+        mock_rank.text = "1."
+        mock_item.select_one.return_value = mock_rank
+
+        mock_titleline = MagicMock()
+        mock_titleline.text.strip.return_value = "Test Article"
+        mock_link = MagicMock()
+        mock_link.get.return_value = "https://example.com"
+        mock_titleline.find.return_value = mock_link
+        mock_item.find.return_value = mock_titleline
+
+        mock_soup.select.return_value = [mock_item]
+
+        docs = loader.load_results(mock_soup)
+
+        assert len(docs) == 1
+        assert docs[0].page_content == "Test Article"
+        assert docs[0].metadata["ranking"] == "1."
+        assert docs[0].metadata["link"] == "https://example.com"
+
+    def test_load_results_with_missing_elements(self) -> None:
+        """Test load_results when elements are missing."""
+        loader = HNLoader("https://news.ycombinator.com/")
+
+        mock_soup = MagicMock()
+
+        # Create a mock item with missing elements
+        mock_item = MagicMock()
+        mock_item.select_one.return_value = None  # No rank element
+        mock_item.find.return_value = None  # No titleline
+
+        mock_soup.select.return_value = [mock_item]
+
+        # This should NOT raise AttributeError
+        docs = loader.load_results(mock_soup)
+
+        assert len(docs) == 1
+        assert docs[0].metadata["ranking"] is None
+        assert docs[0].metadata["link"] is None
+        assert docs[0].metadata["title"] is None
+
+    def test_load_results_with_empty_items(self) -> None:
+        """Test load_results when no items are found."""
+        loader = HNLoader("https://news.ycombinator.com/")
+
+        mock_soup = MagicMock()
+        mock_soup.select.return_value = []
+
+        docs = loader.load_results(mock_soup)
+
+        assert len(docs) == 0


### PR DESCRIPTION
## Description
Fixes #494

Added null checks in [HNLoader](cci:2://file:///Users/sasank/Desktop/open%20source%20projects/langchain-community/libs/community/langchain_community/document_loaders/hn.py:7:0-72:24) to prevent `AttributeError: 'NoneType' object has no attribute 'get'` when loading Hacker News pages where certain HTML elements are missing.

### The Bug
The `select_one()` and `find()` methods return `None` when elements aren't found. The original code called `.get()` or `.text` directly on these results without checking for `None` first.

### The Fix
- [load_comments()](cci:1://file:///Users/sasank/Desktop/open%20source%20projects/langchain-community/libs/community/langchain_community/document_loaders/hn.py:30:4-41:9): Check if [pagespace](cci:1://file:///Users/sasank/Desktop/open%20source%20projects/langchain-community/libs/community/tests/unit_tests/document_loaders/test_hn.py:10:4-28:56) element exists before calling `.get("title")`
- [load_results()](cci:1://file:///Users/sasank/Desktop/open%20source%20projects/langchain-community/libs/community/langchain_community/document_loaders/hn.py:43:4-72:24): Check if `rank`, `titleline`, and `link` elements exist before accessing their attributes

## Issue
This PR closes #494

## Dependencies
None

## Testing
- Added 6 unit tests in [tests/unit_tests/document_loaders/test_hn.py](cci:7://file:///Users/sasank/Desktop/open%20source%20projects/langchain-community/libs/community/tests/unit_tests/document_loaders/test_hn.py:0:0-0:0)
- Tests cover normal operation, the specific bug scenario, and edge cases
- All tests pass locally
- Lint and type checks pass