### PR TITLE
feat(confluence): support xlsx attachments

### DIFF
--- a/libs/community/langchain_community/document_loaders/confluence.py
+++ b/libs/community/langchain_community/document_loaders/confluence.py
@@ -849,7 +849,6 @@ class ConfluenceLoader(BaseLoader):
         return text
 
     def process_xlsx(self, link: str) -> str:
-        """Process .xlsx files using openpyxl."""
         try:
             import openpyxl
         except ImportError:
@@ -859,7 +858,11 @@ class ConfluenceLoader(BaseLoader):
 
         response = self.confluence.request(path=link, absolute=True)
 
-        if response.status_code != 200 or not response.content:
+        if (
+            response.status_code != 200
+            or response.content == b""
+            or response.content is None
+        ):
             logger.warning(f"Failed to download .xlsx from {link}")
             return ""
 
@@ -881,7 +884,10 @@ class ConfluenceLoader(BaseLoader):
 
             return text
 
-        except Exception as e:
+        except (
+            openpyxl.utils.exceptions.InvalidFileException,
+            openpyxl.utils.exceptions.SheetTitleException,
+        ) as e:
             logger.error(f"Error processing .xlsx: {e}")
             return ""
 

--- a/libs/community/langchain_community/document_loaders/confluence.py
+++ b/libs/community/langchain_community/document_loaders/confluence.py
@@ -690,6 +690,11 @@ class ConfluenceLoader(BaseLoader):
                     text = title + self.process_doc(absolute_url)
                 elif media_type == "application/vnd.ms-excel":
                     text = title + self.process_xls(absolute_url)
+                elif (
+                    media_type == "application/vnd.openxmlformats-officedocument"
+                    ".spreadsheetml.sheet"
+                ):
+                    text = title + self.process_xlsx(absolute_url)
                 elif media_type == "image/svg+xml":
                     text = title + self.process_svg(absolute_url, ocr_languages)
                 else:
@@ -842,6 +847,43 @@ class ConfluenceLoader(BaseLoader):
                 text += "\n"
 
         return text
+
+    def process_xlsx(self, link: str) -> str:
+        """Process .xlsx files using openpyxl."""
+        try:
+            import openpyxl
+        except ImportError:
+            raise ImportError(
+                "openpyxl package not found, please run pip install openpyxl"
+            )
+
+        response = self.confluence.request(path=link, absolute=True)
+
+        if response.status_code != 200 or not response.content:
+            logger.warning(f"Failed to download .xlsx from {link}")
+            return ""
+
+        try:
+            excel_file = BytesIO(response.content)
+            workbook = openpyxl.load_workbook(excel_file, data_only=True)
+
+            text = ""
+            for sheet_name in workbook.sheetnames:
+                sheet = workbook[sheet_name]
+                text += f"\n{sheet_name}:\n"
+
+                for row in sheet.iter_rows(values_only=True):
+                    row_text = "\t".join(
+                        str(cell) if cell is not None else "" for cell in row
+                    )
+                    text += f"{row_text}\n"
+                text += "\n"
+
+            return text
+
+        except Exception as e:
+            logger.error(f"Error processing .xlsx: {e}")
+            return ""
 
     def process_svg(
         self,

--- a/libs/community/langchain_community/document_loaders/confluence.py
+++ b/libs/community/langchain_community/document_loaders/confluence.py
@@ -854,7 +854,7 @@ class ConfluenceLoader(BaseLoader):
             import openpyxl
         except ImportError:
             raise ImportError(
-                "openpyxl package not found, please run pip install openpyxl"
+                "`openpyxl` package not found, please run `pip install openpyxl`"
             )
 
         response = self.confluence.request(path=link, absolute=True)

--- a/libs/community/tests/unit_tests/document_loaders/test_confluence.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_confluence.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-import unittest
+from io import BytesIO
 from typing import TYPE_CHECKING, Any, Dict
 from unittest.mock import MagicMock, patch
 
@@ -86,7 +86,7 @@ class TestConfluenceLoader:
     def test_confluence_loader_initialization_from_env(
         self, mock_confluence: MagicMock
     ) -> None:
-        with unittest.mock.patch.dict(
+        with patch.dict(
             "os.environ",
             {
                 "CONFLUENCE_USERNAME": self.MOCK_USERNAME,
@@ -240,6 +240,73 @@ class TestConfluenceLoader:
         assert documents[0].metadata["labels"] == ["l1", "l2"]
         assert documents[1].metadata["labels"] == []
 
+    @pytest.mark.requires("openpyxl")
+    def test_confluence_loader_with_xlsx_attachment(
+        self, mock_confluence: MagicMock
+    ) -> None:
+        mock_confluence.get_page_by_id.side_effect = [self._get_mock_page("123")]
+        mock_confluence.get_all_restrictions_for_content.side_effect = [
+            self._get_mock_page_restrictions("123")
+        ]
+        mock_confluence.get_attachments_from_content.return_value = {
+            "results": [
+                {
+                    "metadata": {
+                        "mediaType": "application/vnd.openxmlformats-officedocument"
+                        ".spreadsheetml.sheet"
+                    },
+                    "_links": {"download": "/download/attachments/123/file.xlsx"},
+                    "title": "file.xlsx",
+                }
+            ]
+        }
+
+        mock_confluence.request.return_value.status_code = 200
+        mock_confluence.request.return_value.content = self._create_xlsx_bytes()
+
+        confluence_loader = self._get_mock_confluence_loader(
+            mock_confluence, page_ids=["123"], include_attachments=True
+        )
+        documents = confluence_loader.load()
+
+        assert len(documents) == 1
+        assert "Sheet1:" in documents[0].page_content
+        assert "a\tb" in documents[0].page_content
+
+    @pytest.mark.requires("openpyxl")
+    def test_confluence_loader_with_xlsx_attachment_failed_download(
+        self, mock_confluence: MagicMock
+    ) -> None:
+        mock_confluence.get_page_by_id.side_effect = [self._get_mock_page("123")]
+        mock_confluence.get_all_restrictions_for_content.side_effect = [
+            self._get_mock_page_restrictions("123")
+        ]
+        mock_confluence.get_attachments_from_content.return_value = {
+            "results": [
+                {
+                    "metadata": {
+                        "mediaType": "application/vnd.openxmlformats-officedocument"
+                        ".spreadsheetml.sheet"
+                    },
+                    "_links": {"download": "/download/attachments/123/file.xlsx"},
+                    "title": "file.xlsx",
+                }
+            ]
+        }
+
+        mock_confluence.request.return_value.status_code = 404
+        mock_confluence.request.return_value.content = b""
+
+        confluence_loader = self._get_mock_confluence_loader(
+            mock_confluence, page_ids=["123"], include_attachments=True
+        )
+        documents = confluence_loader.load()
+
+        assert len(documents) == 1
+        assert "file.xlsx" in documents[0].page_content
+        assert "Sheet1:" not in documents[0].page_content
+        assert "a\tb" not in documents[0].page_content
+
     def _get_mock_confluence_loader(
         self, mock_confluence: MagicMock, **kwargs: Any
     ) -> ConfluenceLoader:
@@ -318,3 +385,16 @@ class TestConfluenceLoader:
                 "context": "/wiki",
             },
         }
+
+    def _create_xlsx_bytes(self) -> bytes:
+        import openpyxl
+
+        workbook = openpyxl.Workbook()
+        sheet = workbook.active
+        if sheet is not None:
+            sheet.title = "Sheet1"
+            sheet.append(["a", "b"])
+
+        buffer = BytesIO()
+        workbook.save(buffer)
+        return buffer.getvalue()


### PR DESCRIPTION
## Description

Adds support for Confluence `.xlsx` attachments in `ConfluenceLoader` by dispatching on the `.xlsx` media type and extracting sheet/row text using `openpyxl`. Includes a minimal unit test covering the happy path and a failed-download path.

Fixes #413 

## Dependencies

- Runtime: `openpyxl` is an optional dependency used only when processing `.xlsx` attachments.
- Tests: the new unit tests are marked with `@pytest.mark.requires("openpyxl")`.

## Tests done

- [x] Ran `make format` locally
- [x] No new linting errors on `make lint`
- [x] New unit tests pass on `make tests`

## Review focus

- Attachment dispatch in `ConfluenceLoader.process_attachment()` for the `.xlsx` media type.
- `process_xlsx()` output formatting (sheet header + tab-separated rows).
