### PR TITLE
community: Add CausalRetriever for .causal knowledge graphs

### DIFF
--- a/libs/community/langchain_community/retrievers/__init__.py
+++ b/libs/community/langchain_community/retrievers/__init__.py
@@ -44,6 +44,9 @@ if TYPE_CHECKING:
     from langchain_community.retrievers.breebs import (
         BreebsRetriever,
     )
+    from langchain_community.retrievers.causal import (
+        CausalRetriever,
+    )
     from langchain_community.retrievers.chaindesk import (
         ChaindeskRetriever,
     )
@@ -156,6 +159,7 @@ _module_lookup = {
     "AzureCognitiveSearchRetriever": "langchain_community.retrievers.azure_ai_search",
     "BM25Retriever": "langchain_community.retrievers.bm25",
     "BreebsRetriever": "langchain_community.retrievers.breebs",
+    "CausalRetriever": "langchain_community.retrievers.causal",
     "ChaindeskRetriever": "langchain_community.retrievers.chaindesk",
     "ChatGPTPluginRetriever": "langchain_community.retrievers.chatgpt_plugin_retriever",
     "CohereRagRetriever": "langchain_community.retrievers.cohere_rag_retriever",
@@ -213,6 +217,7 @@ __all__ = [
     "AzureCognitiveSearchRetriever",
     "BM25Retriever",
     "BreebsRetriever",
+    "CausalRetriever",
     "ChaindeskRetriever",
     "ChatGPTPluginRetriever",
     "CohereRagRetriever",

--- a/libs/community/langchain_community/retrievers/causal.py
+++ b/libs/community/langchain_community/retrievers/causal.py
@@ -1,0 +1,226 @@
+"""Causal Knowledge Graph Retriever for zero-hallucination RAG."""
+
+from typing import Any, Dict, List, Optional
+
+from langchain_core.callbacks import CallbackManagerForRetrieverRun
+from langchain_core.documents import Document
+from langchain_core.retrievers import BaseRetriever
+
+
+class CausalRetriever(BaseRetriever):
+    """.causal knowledge graph retriever for deterministic, zero-hallucination RAG.
+
+    The .causal format is a binary knowledge graph with embedded inference.
+    Unlike vector-based RAG which returns "similar" text, CausalRetriever
+    returns logically connected facts with full provenance.
+
+    Setup:
+        Install ``dotcausal``:
+
+        .. code-block:: bash
+
+            pip install -U dotcausal
+
+    Key init args:
+        file_path: str
+            Path to the .causal knowledge graph file
+        top_k: int
+            Maximum number of results to return (default: 10)
+        include_inferred: bool
+            Whether to include inferred triplets (default: True)
+        min_confidence: float
+            Minimum confidence threshold (default: 0.0)
+
+    Instantiate:
+        .. code-block:: python
+
+            from langchain_community.retrievers import CausalRetriever
+
+            retriever = CausalRetriever(
+                file_path="knowledge.causal",
+                top_k=10,
+                include_inferred=True,
+            )
+
+    Usage:
+        .. code-block:: python
+
+            docs = retriever.invoke("COVID fatigue")
+            docs[0].page_content
+
+        .. code-block:: none
+
+            '[INFERRED] SARS-CoV-2 → damages → mitochondria → causes → chronic fatigue'
+
+        .. code-block:: python
+
+            docs[0].metadata
+
+        .. code-block:: none
+
+            {'trigger': 'SARS-CoV-2',
+             'mechanism': 'indirectly causes',
+             'outcome': 'chronic fatigue',
+             'confidence': 0.765,
+             'is_inferred': True,
+             'provenance': ['triplet_123', 'triplet_456']}
+
+    Use within a chain:
+        .. code-block:: python
+
+            from langchain_core.output_parsers import StrOutputParser
+            from langchain_core.prompts import ChatPromptTemplate
+            from langchain_core.runnables import RunnablePassthrough
+            from langchain_openai import ChatOpenAI
+
+            prompt = ChatPromptTemplate.from_template(
+                \"\"\"Answer based on these verified facts (zero hallucination):
+
+            {context}
+
+            Question: {question}\"\"\"
+            )
+
+            llm = ChatOpenAI(model="gpt-4")
+
+            def format_docs(docs):
+                return "\\n".join(doc.page_content for doc in docs)
+
+            chain = (
+                {"context": retriever | format_docs, "question": RunnablePassthrough()}
+                | prompt
+                | llm
+                | StrOutputParser()
+            )
+
+            chain.invoke("What mechanisms connect COVID to chronic fatigue?")
+
+    References:
+        - dotcausal PyPI: https://pypi.org/project/dotcausal/
+        - GitHub: https://github.com/DT-Foss/dotcausal
+        - Whitepaper: https://doi.org/10.5281/zenodo.18326222
+    """
+
+    file_path: str
+    """Path to the .causal knowledge graph file."""
+
+    top_k: int = 10
+    """Maximum number of results to return."""
+
+    include_inferred: bool = True
+    """Whether to include inferred (derived) triplets."""
+
+    min_confidence: float = 0.0
+    """Minimum confidence threshold for results."""
+
+    _reader: Optional[Any] = None
+
+    class Config:
+        arbitrary_types_allowed = True
+
+    def __init__(
+        self,
+        file_path: str,
+        top_k: int = 10,
+        include_inferred: bool = True,
+        min_confidence: float = 0.0,
+        **kwargs: Any,
+    ) -> None:
+        """Initialize the CausalRetriever.
+
+        Args:
+            file_path: Path to the .causal knowledge graph file
+            top_k: Maximum number of results to return
+            include_inferred: Whether to include inferred triplets
+            min_confidence: Minimum confidence threshold
+        """
+        super().__init__(
+            file_path=file_path,
+            top_k=top_k,
+            include_inferred=include_inferred,
+            min_confidence=min_confidence,
+            **kwargs,
+        )
+        self._load_reader()
+
+    def _load_reader(self) -> None:
+        """Load the .causal file using dotcausal."""
+        try:
+            from dotcausal import CausalReader
+        except ImportError as e:
+            raise ImportError(
+                "Could not import dotcausal. "
+                "Please install it with: pip install dotcausal"
+            ) from e
+
+        from pathlib import Path
+
+        if not Path(self.file_path).exists():
+            raise FileNotFoundError(f"Causal file not found: {self.file_path}")
+
+        self._reader = CausalReader(self.file_path)
+
+    def _get_relevant_documents(
+        self,
+        query: str,
+        *,
+        run_manager: Optional[CallbackManagerForRetrieverRun] = None,
+    ) -> List[Document]:
+        """Retrieve relevant documents from the knowledge graph.
+
+        Args:
+            query: The search query
+            run_manager: Callback manager (optional)
+
+        Returns:
+            List of Document objects with causal triplets
+        """
+        if self._reader is None:
+            raise ValueError("Reader not initialized. Call _load_reader() first.")
+
+        # Search the knowledge graph
+        results = self._reader.search(
+            query=query,
+            limit=self.top_k * 2,  # Get more to filter
+        )
+
+        # Filter by confidence and inferred status
+        filtered = []
+        for r in results:
+            if r.get("confidence", 1.0) < self.min_confidence:
+                continue
+            if not self.include_inferred and r.get("is_inferred", False):
+                continue
+            filtered.append(r)
+            if len(filtered) >= self.top_k:
+                break
+
+        # Convert to LangChain Documents
+        documents = []
+        for r in filtered:
+            tag = "[INFERRED]" if r.get("is_inferred") else "[EXPLICIT]"
+            content = f"{tag} {r['trigger']} → {r['mechanism']} → {r['outcome']}"
+
+            metadata: Dict[str, Any] = {
+                "trigger": r["trigger"],
+                "mechanism": r["mechanism"],
+                "outcome": r["outcome"],
+                "confidence": r.get("confidence", 1.0),
+                "is_inferred": r.get("is_inferred", False),
+                "source": r.get("source", ""),
+                "provenance": r.get("provenance", []),
+            }
+
+            documents.append(Document(page_content=content, metadata=metadata))
+
+        return documents
+
+    def get_stats(self) -> Dict[str, Any]:
+        """Get statistics about the loaded knowledge graph.
+
+        Returns:
+            Dictionary with triplet counts and amplification stats
+        """
+        if self._reader is None:
+            raise ValueError("Reader not initialized.")
+        return self._reader.get_stats()

--- a/libs/community/tests/unit_tests/retrievers/test_causal.py
+++ b/libs/community/tests/unit_tests/retrievers/test_causal.py
@@ -1,0 +1,146 @@
+"""Tests for CausalRetriever."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+@pytest.mark.requires("dotcausal")
+def test_causal_retriever_import() -> None:
+    """Test that CausalRetriever can be imported."""
+    from langchain_community.retrievers import CausalRetriever
+
+    assert CausalRetriever is not None
+
+
+@pytest.mark.requires("dotcausal")
+def test_causal_retriever_initialization() -> None:
+    """Test CausalRetriever initialization with mocked reader."""
+    from langchain_community.retrievers.causal import CausalRetriever
+
+    with patch("langchain_community.retrievers.causal.CausalReader") as mock_reader:
+        with patch("pathlib.Path.exists", return_value=True):
+            mock_reader_instance = MagicMock()
+            mock_reader.return_value = mock_reader_instance
+
+            retriever = CausalRetriever(
+                file_path="test.causal",
+                top_k=5,
+                include_inferred=True,
+                min_confidence=0.5,
+            )
+
+            assert retriever.file_path == "test.causal"
+            assert retriever.top_k == 5
+            assert retriever.include_inferred is True
+            assert retriever.min_confidence == 0.5
+
+
+@pytest.mark.requires("dotcausal")
+def test_causal_retriever_search() -> None:
+    """Test CausalRetriever search functionality."""
+    from langchain_community.retrievers.causal import CausalRetriever
+
+    with patch("langchain_community.retrievers.causal.CausalReader") as mock_reader:
+        with patch("pathlib.Path.exists", return_value=True):
+            mock_reader_instance = MagicMock()
+            mock_reader_instance.search.return_value = [
+                {
+                    "trigger": "COVID",
+                    "mechanism": "causes",
+                    "outcome": "fatigue",
+                    "confidence": 0.9,
+                    "is_inferred": False,
+                    "source": "paper1.pdf",
+                },
+                {
+                    "trigger": "SARS-CoV-2",
+                    "mechanism": "damages",
+                    "outcome": "mitochondria",
+                    "confidence": 0.85,
+                    "is_inferred": True,
+                    "provenance": ["triplet_1", "triplet_2"],
+                },
+            ]
+            mock_reader.return_value = mock_reader_instance
+
+            retriever = CausalRetriever(file_path="test.causal", top_k=10)
+            docs = retriever.invoke("COVID")
+
+            assert len(docs) == 2
+            assert "[EXPLICIT]" in docs[0].page_content
+            assert "[INFERRED]" in docs[1].page_content
+            assert docs[0].metadata["trigger"] == "COVID"
+            assert docs[1].metadata["is_inferred"] is True
+
+
+@pytest.mark.requires("dotcausal")
+def test_causal_retriever_confidence_filter() -> None:
+    """Test that min_confidence filter works."""
+    from langchain_community.retrievers.causal import CausalRetriever
+
+    with patch("langchain_community.retrievers.causal.CausalReader") as mock_reader:
+        with patch("pathlib.Path.exists", return_value=True):
+            mock_reader_instance = MagicMock()
+            mock_reader_instance.search.return_value = [
+                {
+                    "trigger": "A",
+                    "mechanism": "causes",
+                    "outcome": "B",
+                    "confidence": 0.9,
+                    "is_inferred": False,
+                },
+                {
+                    "trigger": "C",
+                    "mechanism": "causes",
+                    "outcome": "D",
+                    "confidence": 0.3,  # Below threshold
+                    "is_inferred": False,
+                },
+            ]
+            mock_reader.return_value = mock_reader_instance
+
+            retriever = CausalRetriever(
+                file_path="test.causal", min_confidence=0.5
+            )
+            docs = retriever.invoke("test")
+
+            # Only high confidence result should be returned
+            assert len(docs) == 1
+            assert docs[0].metadata["confidence"] == 0.9
+
+
+@pytest.mark.requires("dotcausal")
+def test_causal_retriever_exclude_inferred() -> None:
+    """Test that include_inferred=False filters out inferred triplets."""
+    from langchain_community.retrievers.causal import CausalRetriever
+
+    with patch("langchain_community.retrievers.causal.CausalReader") as mock_reader:
+        with patch("pathlib.Path.exists", return_value=True):
+            mock_reader_instance = MagicMock()
+            mock_reader_instance.search.return_value = [
+                {
+                    "trigger": "A",
+                    "mechanism": "causes",
+                    "outcome": "B",
+                    "confidence": 0.9,
+                    "is_inferred": False,
+                },
+                {
+                    "trigger": "C",
+                    "mechanism": "causes",
+                    "outcome": "D",
+                    "confidence": 0.85,
+                    "is_inferred": True,  # Should be filtered
+                },
+            ]
+            mock_reader.return_value = mock_reader_instance
+
+            retriever = CausalRetriever(
+                file_path="test.causal", include_inferred=False
+            )
+            docs = retriever.invoke("test")
+
+            # Only explicit result should be returned
+            assert len(docs) == 1
+            assert docs[0].metadata["is_inferred"] is False


### PR DESCRIPTION
## Description

This PR adds `CausalRetriever` - a retriever for the `.causal` binary knowledge graph format with embedded deterministic inference.

### What is .causal?

The `.causal` format solves the fundamental problem of AI-assisted discovery: **LLMs hallucinate, databases don't reason**.

| Technology | What it does | What's missing |
|------------|--------------|----------------|
| **SQLite** | Stores facts | No reasoning |
| **Vector RAG** | Finds similar text | No logic |
| **LLMs** | Reasons creatively | Hallucination risk |
| **.causal** | Stores + Reasons | Zero hallucination |

### Key Features

- **Deterministic inference**: Pre-computed transitive chains at storage time
- **Zero hallucination**: Every inference has full provenance
- **30-40x faster queries**: 1.1ms vs 41.5ms (SQLite)
- **50-200% fact amplification**: Weak signals become visible

### Usage

```python
from langchain_community.retrievers import CausalRetriever

retriever = CausalRetriever(file_path="knowledge.causal", top_k=10)
docs = retriever.invoke("COVID fatigue")

# Returns Documents with rich metadata
# - is_inferred: bool
# - confidence: float
# - provenance: list of source triplets
```

### In a chain

```python
from langchain_openai import ChatOpenAI
from langchain_core.prompts import ChatPromptTemplate

prompt = ChatPromptTemplate.from_template(
    "Answer based on verified facts:\n{context}\n\nQuestion: {question}"
)

chain = (
    {"context": retriever, "question": lambda x: x}
    | prompt
    | ChatOpenAI()
)

response = chain.invoke("What causes fatigue in COVID patients?")
```

## Dependencies

- `dotcausal` (optional dependency, installed separately)

```bash
pip install dotcausal
```

## References

- **PyPI**: https://pypi.org/project/dotcausal/
- **GitHub**: https://github.com/DT-Foss/dotcausal
- **Whitepaper**: https://doi.org/10.5281/zenodo.18326222

## Tests

Unit tests included with mocked CausalReader to avoid file dependencies.