### PR TITLE
fix(vectorstores): Add validation to check if the dimensions of the pickle's index are matching with the embeddings dimension.

### DIFF
--- a/libs/community/langchain_community/vectorstores/faiss.py
+++ b/libs/community/langchain_community/vectorstores/faiss.py
@@ -1251,6 +1251,8 @@ class FAISS(VectorStore):
         ) = pickle.loads(  # ignore[pickle]: explicit-opt-in
             serialized
         )
+
+        # Check if the embeddings dimension matches the index dimension
         if index.d != len(embeddings.embed_query("dim_check")):
             raise ValueError(
                 "The provided embeddings dimension does not match the "


### PR DESCRIPTION
- **Description:** Adds a check to validate the dimensions of the embeddings and index from pickle.
- **Issue:** If user passes in wrong embeddings model, the function is still working instead it should throw an error letting the user know to use the same embeddings model used to instantiate the vectorstore.
