### PR TITLE
fix(gitbook): Makes content_selector work well when configured as a CSS selector

### DIFF
--- a/libs/community/langchain_community/document_loaders/gitbook.py
+++ b/libs/community/langchain_community/document_loaders/gitbook.py
@@ -366,7 +366,7 @@ class GitbookLoader(BaseLoader):
         self, soup: Any, custom_url: Optional[str] = None
     ) -> Optional[Document]:
         """Fetch content from page and return Document."""
-        page_content_raw = soup.find(self.content_selector)
+        page_content_raw = soup.select_one(self.content_selector)
         if not page_content_raw:
             return None
         content = page_content_raw.get_text(separator="\n").strip()

--- a/libs/community/tests/unit_tests/document_loaders/test_gitbook.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_gitbook.py
@@ -25,7 +25,7 @@ def mock_soups() -> Tuple[BeautifulSoup, BeautifulSoup]:
     page_content = """
     <html>
         <body>
-            <main>
+            <main id="body">
                 <h1>Test Page</h1>
                 <p>This is test content.</p>
             </main>
@@ -312,3 +312,17 @@ def test_ssrf_protection_validation() -> None:
         GitbookLoader(
             web_page="https://attacker.com/page", allowed_domains={"example.com"}
         )
+def test_content_selector_css_selector(
+    mock_soups: Tuple[BeautifulSoup, BeautifulSoup],
+) -> None:
+    """Test that content_selector supports CSS selectors (e.g. #id)."""
+    _, mock_page_soup = mock_soups
+    loader = GitbookLoader(
+        web_page="https://example.com",
+        load_all_paths=False,
+        content_selector="#body",
+    )
+    doc = loader._get_document(mock_page_soup, "https://example.com/page")
+    assert doc is not None
+    assert doc.metadata["title"] == "Test Page"
+    assert "This is test content." in doc.page_content


### PR DESCRIPTION
Although the current description of `content_selector` is: `The CSS selector for the content to load.`, it seems to only be configurable as an HTML element name.
Use `soup.select_one`(self.content_selector)` instead of `soup.find(self.content_selector)` to makes `content_selector` work well when it configured as a CSS selector

closes #515 