### PR TITLE
Add MCPDiscoveryTool for MCP server discovery

### DIFF
--- a/libs/community/langchain_community/tools/__init__.py
+++ b/libs/community/langchain_community/tools/__init__.py
@@ -346,6 +346,7 @@ if TYPE_CHECKING:
         ZenGuardTool,
     )
 
+
 __all__ = [
     "BaseTool",
     "Tool",

--- a/libs/community/langchain_community/tools/mcp_discovery/__init__.py
+++ b/libs/community/langchain_community/tools/mcp_discovery/__init__.py
@@ -1,0 +1,3 @@
+from langchain_community.tools.mcp_discovery.tool import MCPDiscoveryTool
+
+__all__ = ["MCPDiscoveryTool"]

--- a/libs/community/langchain_community/tools/mcp_discovery/tool.py
+++ b/libs/community/langchain_community/tools/mcp_discovery/tool.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from typing import Type
+
+import requests
+from pydantic import BaseModel, Field
+
+from langchain_core.tools import BaseTool
+
+
+class MCPDiscoveryInput(BaseModel):
+    """Input for MCP Discovery tool."""
+
+    query: str = Field(
+        ...,
+        description="Task description used to discover relevant MCP servers.",
+    )
+
+
+class MCPDiscoveryTool(BaseTool):
+    """Tool for discovering MCP servers dynamically via MCP Discovery API."""
+
+    name: str = "mcp_discovery"
+    description: str = (
+        "Discover MCP servers dynamically based on a user query or task requirement."
+    )
+
+    api_url: str = "https://mcp-discovery-production.up.railway.app"
+
+    args_schema: Type[BaseModel] = MCPDiscoveryInput
+
+    def _run(self, query: str) -> dict:
+        """Run MCP discovery search query."""
+        response = requests.get(
+            f"{self.api_url}/search",
+            params={"q": query},
+            timeout=10,
+        )
+        response.raise_for_status()
+        return response.json()

--- a/libs/community/tests/unit_tests/tools/test_mcp_discovery.py
+++ b/libs/community/tests/unit_tests/tools/test_mcp_discovery.py
@@ -1,0 +1,6 @@
+from langchain_community.tools.mcp_discovery import MCPDiscoveryTool
+
+
+def test_mcp_discovery_tool_name():
+    tool = MCPDiscoveryTool()
+    assert tool.name == "mcp_discovery"


### PR DESCRIPTION
## Summary
Implements `MCPDiscoveryTool` for dynamic MCP server discovery via MCP Discovery API.

## Changes
- Added new tool under `langchain_community.tools.mcp_discovery`
- Exported tool in tools __init__
- Added unit test for tool name

## Tests
- `python -m pytest tests/unit_tests/tools/test_mcp_discovery.py -v`