### PR TITLE
feat: Add AteChatMessageHistory — portable .mv2 memory for chat history

### DIFF
--- a/libs/community/langchain_community/chat_message_histories/__init__.py
+++ b/libs/community/langchain_community/chat_message_histories/__init__.py
@@ -19,6 +19,9 @@ import importlib
 from typing import TYPE_CHECKING, Any
 
 if TYPE_CHECKING:
+    from langchain_community.chat_message_histories.ate import (
+        AteChatMessageHistory,
+    )
     from langchain_community.chat_message_histories.astradb import (
         AstraDBChatMessageHistory,
     )
@@ -90,6 +93,7 @@ if TYPE_CHECKING:
     )
 
 __all__ = [
+    "AteChatMessageHistory",
     "AstraDBChatMessageHistory",
     "CassandraChatMessageHistory",
     "ChatMessageHistory",
@@ -116,6 +120,7 @@ __all__ = [
 ]
 
 _module_lookup = {
+    "AteChatMessageHistory": "langchain_community.chat_message_histories.ate",
     "AstraDBChatMessageHistory": "langchain_community.chat_message_histories.astradb",
     "CassandraChatMessageHistory": "langchain_community.chat_message_histories.cassandra",  # noqa: E501
     "ChatMessageHistory": "langchain_community.chat_message_histories.in_memory",

--- a/libs/community/langchain_community/chat_message_histories/ate.py
+++ b/libs/community/langchain_community/chat_message_histories/ate.py
@@ -1,0 +1,227 @@
+"""Chat message history backed by FoodForThought's ate CLI (.mv2 format)."""
+
+from __future__ import annotations
+
+import json
+import logging
+import shutil
+import subprocess
+from typing import List, Optional, Sequence
+
+from langchain_core.chat_history import BaseChatMessageHistory
+from langchain_core.messages import BaseMessage, message_to_dict, messages_from_dict
+
+logger = logging.getLogger(__name__)
+
+
+class AteChatMessageHistory(BaseChatMessageHistory):
+    """Chat message history that stores messages in a .mv2 memory file
+    via the ``ate`` CLI from FoodForThought.
+
+    Unlike :class:`FileChatMessageHistory`, ate-backed history supports:
+
+    * **Semantic search** over past messages
+    * **Tagged memories** with arbitrary metadata
+    * **AES-256 encryption** at rest
+    * **Multi-agent concurrent access** via file-level locking
+
+    Each message is stored as a memory entry whose ``text`` field holds the
+    LangChain-serialised message dict and whose ``tags`` encode the
+    ``session_id`` and message type (``human``, ``ai``, ``system``, …).
+
+    Parameters
+    ----------
+    session_id:
+        Unique identifier for this conversation session.  Used to filter
+        memories so that multiple sessions can share the same .mv2 file.
+    memory_path:
+        Filesystem path to the ``.mv2`` memory file.
+    auto_init:
+        When *True* (the default) the constructor will run
+        ``ate memory init`` if the *memory_path* does not yet exist.
+
+    Raises
+    ------
+    ImportError
+        If the ``ate`` CLI is not found on ``$PATH``.
+    RuntimeError
+        If ``ate memory init`` fails during auto-initialisation.
+
+    Example
+    -------
+    .. code-block:: python
+
+        from langchain_community.chat_message_histories import AteChatMessageHistory
+
+        history = AteChatMessageHistory(
+            session_id="user-42",
+            memory_path="./chat.mv2",
+        )
+        history.add_user_message("Hello!")
+        history.add_ai_message("Hi there!")
+        print(history.messages)
+    """
+
+    def __init__(
+        self,
+        session_id: str,
+        memory_path: str,
+        *,
+        auto_init: bool = True,
+    ) -> None:
+        if not shutil.which("ate"):
+            raise ImportError(
+                "Could not find the `ate` CLI on $PATH.  "
+                "Install it with `pip install ate-memory` or "
+                "`brew install ate-cli`.  "
+                "See https://kindly.fyi/foodforthought for details."
+            )
+        if not session_id:
+            raise ValueError("session_id must be a non-empty string.")
+        if not memory_path:
+            raise ValueError("memory_path must be a non-empty string.")
+
+        self.session_id = session_id
+        self.memory_path = memory_path
+
+        if auto_init:
+            self._ensure_initialised()
+
+    # ------------------------------------------------------------------
+    # BaseChatMessageHistory interface
+    # ------------------------------------------------------------------
+
+    @property
+    def messages(self) -> List[BaseMessage]:  # type: ignore[override]
+        """Return all messages for this session from the .mv2 file."""
+        raw = self._run_ate(
+            ["ate", "memory", "export", "--path", self.memory_path, "--format", "json"]
+        )
+        if not raw.strip():
+            return []
+
+        try:
+            entries: list = json.loads(raw)
+        except json.JSONDecodeError:
+            logger.warning("Failed to parse ate export output as JSON.")
+            return []
+
+        if not isinstance(entries, list):
+            logger.warning("ate export did not return a JSON array.")
+            return []
+
+        session_tag = f"session:{self.session_id}"
+        filtered: list[dict] = []
+        for entry in entries:
+            tags: Sequence[str] = entry.get("tags", [])
+            if session_tag in tags:
+                try:
+                    msg_dict = json.loads(entry.get("text", "{}"))
+                    filtered.append(msg_dict)
+                except json.JSONDecodeError:
+                    logger.warning(
+                        "Skipping memory entry with non-JSON text: %s",
+                        entry.get("id", "<unknown>"),
+                    )
+
+        if not filtered:
+            return []
+
+        return messages_from_dict(filtered)
+
+    def add_message(self, message: BaseMessage) -> None:
+        """Persist a single message to the .mv2 file."""
+        serialised = json.dumps(message_to_dict(message))
+        msg_type = message.type  # "human", "ai", "system", etc.
+        tags = f"session:{self.session_id},type:{msg_type}"
+
+        self._run_ate(
+            [
+                "ate",
+                "memory",
+                "add",
+                "--path",
+                self.memory_path,
+                "--text",
+                serialised,
+                "--tags",
+                tags,
+                "--format",
+                "json",
+            ]
+        )
+
+    def clear(self) -> None:
+        """Re-initialise the .mv2 file, destroying **all** sessions."""
+        self._run_ate(
+            ["ate", "memory", "init", "--path", self.memory_path]
+        )
+
+    # ------------------------------------------------------------------
+    # Helpers
+    # ------------------------------------------------------------------
+
+    def _ensure_initialised(self) -> None:
+        """Run ``ate memory init`` if the memory file does not exist."""
+        import os
+
+        if not os.path.exists(self.memory_path):
+            result = self._run_ate(
+                ["ate", "memory", "init", "--path", self.memory_path],
+                check=True,
+            )
+            if result is None:
+                raise RuntimeError(
+                    f"Failed to initialise ate memory at {self.memory_path}"
+                )
+
+    @staticmethod
+    def _run_ate(
+        cmd: list[str],
+        *,
+        check: bool = False,
+    ) -> str:
+        """Execute an ate CLI command and return its stdout.
+
+        Parameters
+        ----------
+        cmd:
+            Full command list, e.g. ``["ate", "memory", "export", ...]``.
+        check:
+            If *True*, raise :class:`RuntimeError` on non-zero exit.
+
+        Returns
+        -------
+        str
+            The stdout of the process (stripped).
+        """
+        try:
+            proc = subprocess.run(
+                cmd,
+                capture_output=True,
+                text=True,
+                timeout=30,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise RuntimeError(
+                f"ate CLI timed out after 30 s: {' '.join(cmd)}"
+            ) from exc
+        except FileNotFoundError as exc:
+            raise RuntimeError(
+                "ate CLI not found when attempting to run command."
+            ) from exc
+
+        if check and proc.returncode != 0:
+            raise RuntimeError(
+                f"ate CLI returned non-zero exit code {proc.returncode}: "
+                f"{proc.stderr.strip()}"
+            )
+
+        if proc.returncode != 0:
+            logger.warning(
+                "ate CLI returned exit code %d: %s",
+                proc.returncode,
+                proc.stderr.strip(),
+            )
+
+        return proc.stdout.strip()

--- a/libs/community/tests/unit_tests/chat_message_histories/test_ate_chat_message_history.py
+++ b/libs/community/tests/unit_tests/chat_message_histories/test_ate_chat_message_history.py
@@ -1,0 +1,437 @@
+"""Unit tests for AteChatMessageHistory.
+
+All subprocess and shutil.which calls are fully mocked — no real CLI
+invocations happen during testing.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+from typing import Any
+from unittest.mock import MagicMock, patch
+
+import pytest
+from langchain_core.messages import (
+    AIMessage,
+    HumanMessage,
+    SystemMessage,
+    message_to_dict,
+)
+
+from langchain_community.chat_message_histories.ate import AteChatMessageHistory
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_export_json(entries: list[dict[str, Any]]) -> str:
+    """Build the JSON string that ``ate memory export`` would return."""
+    return json.dumps(entries)
+
+
+def _make_memory_entry(
+    message: Any,
+    session_id: str,
+    entry_id: str = "mem-1",
+) -> dict[str, Any]:
+    """Build a single memory entry dict as returned by ate export."""
+    msg_dict = message_to_dict(message)
+    return {
+        "id": entry_id,
+        "text": json.dumps(msg_dict),
+        "tags": [f"session:{session_id}", f"type:{message.type}"],
+    }
+
+
+def _completed_process(stdout: str = "", returncode: int = 0) -> subprocess.CompletedProcess:
+    return subprocess.CompletedProcess(
+        args=[], returncode=returncode, stdout=stdout, stderr=""
+    )
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+@pytest.fixture()
+def mock_which():
+    """Patch shutil.which so it always finds 'ate'."""
+    with patch("langchain_community.chat_message_histories.ate.shutil.which", return_value="/usr/local/bin/ate"):
+        yield
+
+
+@pytest.fixture()
+def mock_subprocess(mock_which):
+    """Patch subprocess.run to return an empty success by default."""
+    with patch("langchain_community.chat_message_histories.ate.subprocess.run", return_value=_completed_process()) as m:
+        yield m
+
+
+@pytest.fixture()
+def mock_no_file(mock_which):
+    """Patch os.path.exists to return False (file doesn't exist yet)."""
+    with patch("os.path.exists", return_value=False):
+        with patch("langchain_community.chat_message_histories.ate.subprocess.run", return_value=_completed_process()) as m:
+            yield m
+
+
+@pytest.fixture()
+def mock_file_exists(mock_which):
+    """Patch os.path.exists to return True."""
+    with patch("os.path.exists", return_value=True):
+        with patch("langchain_community.chat_message_histories.ate.subprocess.run", return_value=_completed_process()) as m:
+            yield m
+
+
+@pytest.fixture()
+def history(mock_file_exists):
+    """Return a ready-to-use history instance (file already exists)."""
+    return AteChatMessageHistory(
+        session_id="test-session",
+        memory_path="/tmp/test.mv2",
+    )
+
+
+# ===========================================================================
+# 1. Constructor tests
+# ===========================================================================
+
+class TestConstructor:
+    def test_raises_when_ate_not_found(self):
+        with patch("langchain_community.chat_message_histories.ate.shutil.which", return_value=None):
+            with pytest.raises(ImportError, match="Could not find the `ate` CLI"):
+                AteChatMessageHistory(session_id="s", memory_path="/tmp/test.mv2")
+
+    def test_raises_on_empty_session_id(self, mock_which):
+        with patch("os.path.exists", return_value=True):
+            with patch("langchain_community.chat_message_histories.ate.subprocess.run", return_value=_completed_process()):
+                with pytest.raises(ValueError, match="session_id"):
+                    AteChatMessageHistory(session_id="", memory_path="/tmp/x.mv2")
+
+    def test_raises_on_empty_memory_path(self, mock_which):
+        with patch("os.path.exists", return_value=True):
+            with patch("langchain_community.chat_message_histories.ate.subprocess.run", return_value=_completed_process()):
+                with pytest.raises(ValueError, match="memory_path"):
+                    AteChatMessageHistory(session_id="s", memory_path="")
+
+    def test_auto_init_creates_file(self, mock_no_file):
+        h = AteChatMessageHistory(session_id="s", memory_path="/tmp/new.mv2")
+        # Should have called ate memory init
+        mock_no_file.assert_called_once()
+        cmd = mock_no_file.call_args[0][0]
+        assert cmd == ["ate", "memory", "init", "--path", "/tmp/new.mv2"]
+
+    def test_auto_init_skips_when_file_exists(self, mock_file_exists):
+        h = AteChatMessageHistory(session_id="s", memory_path="/tmp/existing.mv2")
+        # subprocess.run should NOT have been called (no init needed)
+        mock_file_exists.assert_not_called()
+
+    def test_auto_init_false_skips_init(self, mock_which):
+        with patch("langchain_community.chat_message_histories.ate.subprocess.run") as mock_run:
+            h = AteChatMessageHistory(
+                session_id="s", memory_path="/tmp/x.mv2", auto_init=False
+            )
+            mock_run.assert_not_called()
+
+    def test_auto_init_failure_raises_runtime_error(self, mock_which):
+        with patch("os.path.exists", return_value=False):
+            with patch(
+                "langchain_community.chat_message_histories.ate.subprocess.run",
+                return_value=_completed_process(returncode=1),
+            ):
+                with pytest.raises(RuntimeError, match="non-zero exit code"):
+                    AteChatMessageHistory(session_id="s", memory_path="/tmp/x.mv2")
+
+    def test_stores_session_id_and_path(self, mock_file_exists):
+        h = AteChatMessageHistory(session_id="abc", memory_path="/data/chat.mv2")
+        assert h.session_id == "abc"
+        assert h.memory_path == "/data/chat.mv2"
+
+
+# ===========================================================================
+# 2. messages property tests
+# ===========================================================================
+
+class TestMessagesProperty:
+    def test_empty_export(self, history, mock_file_exists):
+        mock_file_exists.return_value = _completed_process(stdout="")
+        assert history.messages == []
+
+    def test_empty_array_export(self, history, mock_file_exists):
+        mock_file_exists.return_value = _completed_process(stdout="[]")
+        assert history.messages == []
+
+    def test_returns_human_message(self, history, mock_file_exists):
+        entry = _make_memory_entry(HumanMessage(content="hi"), "test-session")
+        mock_file_exists.return_value = _completed_process(
+            stdout=_make_export_json([entry])
+        )
+        msgs = history.messages
+        assert len(msgs) == 1
+        assert isinstance(msgs[0], HumanMessage)
+        assert msgs[0].content == "hi"
+
+    def test_returns_ai_message(self, history, mock_file_exists):
+        entry = _make_memory_entry(AIMessage(content="hello"), "test-session")
+        mock_file_exists.return_value = _completed_process(
+            stdout=_make_export_json([entry])
+        )
+        msgs = history.messages
+        assert len(msgs) == 1
+        assert isinstance(msgs[0], AIMessage)
+
+    def test_returns_system_message(self, history, mock_file_exists):
+        entry = _make_memory_entry(SystemMessage(content="sys"), "test-session")
+        mock_file_exists.return_value = _completed_process(
+            stdout=_make_export_json([entry])
+        )
+        msgs = history.messages
+        assert len(msgs) == 1
+        assert isinstance(msgs[0], SystemMessage)
+
+    def test_filters_by_session_id(self, history, mock_file_exists):
+        mine = _make_memory_entry(HumanMessage(content="mine"), "test-session", "m1")
+        other = _make_memory_entry(HumanMessage(content="other"), "other-session", "m2")
+        mock_file_exists.return_value = _completed_process(
+            stdout=_make_export_json([mine, other])
+        )
+        msgs = history.messages
+        assert len(msgs) == 1
+        assert msgs[0].content == "mine"
+
+    def test_multiple_messages_preserve_order(self, history, mock_file_exists):
+        entries = [
+            _make_memory_entry(HumanMessage(content="first"), "test-session", "m1"),
+            _make_memory_entry(AIMessage(content="second"), "test-session", "m2"),
+            _make_memory_entry(HumanMessage(content="third"), "test-session", "m3"),
+        ]
+        mock_file_exists.return_value = _completed_process(
+            stdout=_make_export_json(entries)
+        )
+        msgs = history.messages
+        assert len(msgs) == 3
+        assert msgs[0].content == "first"
+        assert msgs[1].content == "second"
+        assert msgs[2].content == "third"
+
+    def test_invalid_json_returns_empty(self, history, mock_file_exists):
+        mock_file_exists.return_value = _completed_process(stdout="NOT JSON")
+        assert history.messages == []
+
+    def test_non_list_json_returns_empty(self, history, mock_file_exists):
+        mock_file_exists.return_value = _completed_process(stdout='{"key": "value"}')
+        assert history.messages == []
+
+    def test_entry_with_bad_text_skipped(self, history, mock_file_exists):
+        good = _make_memory_entry(HumanMessage(content="good"), "test-session", "m1")
+        bad = {
+            "id": "m2",
+            "text": "NOT-VALID-JSON",
+            "tags": ["session:test-session", "type:human"],
+        }
+        mock_file_exists.return_value = _completed_process(
+            stdout=_make_export_json([good, bad])
+        )
+        msgs = history.messages
+        assert len(msgs) == 1
+        assert msgs[0].content == "good"
+
+    def test_export_calls_correct_command(self, history, mock_file_exists):
+        mock_file_exists.return_value = _completed_process(stdout="[]")
+        _ = history.messages
+        cmd = mock_file_exists.call_args[0][0]
+        assert cmd == [
+            "ate", "memory", "export",
+            "--path", "/tmp/test.mv2",
+            "--format", "json",
+        ]
+
+
+# ===========================================================================
+# 3. add_message tests
+# ===========================================================================
+
+class TestAddMessage:
+    def test_add_human_message(self, history, mock_file_exists):
+        msg = HumanMessage(content="hello")
+        history.add_message(msg)
+        mock_file_exists.assert_called_once()
+        cmd = mock_file_exists.call_args[0][0]
+        assert cmd[0:3] == ["ate", "memory", "add"]
+        assert "--path" in cmd
+        assert "--text" in cmd
+        assert "--tags" in cmd
+
+    def test_add_ai_message(self, history, mock_file_exists):
+        msg = AIMessage(content="reply")
+        history.add_message(msg)
+        cmd = mock_file_exists.call_args[0][0]
+        tags_idx = cmd.index("--tags") + 1
+        assert "type:ai" in cmd[tags_idx]
+
+    def test_add_system_message(self, history, mock_file_exists):
+        msg = SystemMessage(content="sys prompt")
+        history.add_message(msg)
+        cmd = mock_file_exists.call_args[0][0]
+        tags_idx = cmd.index("--tags") + 1
+        assert "type:system" in cmd[tags_idx]
+
+    def test_tags_contain_session_id(self, history, mock_file_exists):
+        history.add_message(HumanMessage(content="x"))
+        cmd = mock_file_exists.call_args[0][0]
+        tags_idx = cmd.index("--tags") + 1
+        assert "session:test-session" in cmd[tags_idx]
+
+    def test_text_is_valid_json(self, history, mock_file_exists):
+        msg = HumanMessage(content="check json")
+        history.add_message(msg)
+        cmd = mock_file_exists.call_args[0][0]
+        text_idx = cmd.index("--text") + 1
+        parsed = json.loads(cmd[text_idx])
+        assert parsed["data"]["content"] == "check json"
+
+    def test_add_message_includes_format_json(self, history, mock_file_exists):
+        history.add_message(HumanMessage(content="x"))
+        cmd = mock_file_exists.call_args[0][0]
+        assert "--format" in cmd
+        fmt_idx = cmd.index("--format") + 1
+        assert cmd[fmt_idx] == "json"
+
+    def test_add_user_message_convenience(self, history, mock_file_exists):
+        history.add_user_message("hi")
+        cmd = mock_file_exists.call_args[0][0]
+        tags_idx = cmd.index("--tags") + 1
+        assert "type:human" in cmd[tags_idx]
+
+    def test_add_ai_message_convenience(self, history, mock_file_exists):
+        history.add_ai_message("hello")
+        cmd = mock_file_exists.call_args[0][0]
+        tags_idx = cmd.index("--tags") + 1
+        assert "type:ai" in cmd[tags_idx]
+
+
+# ===========================================================================
+# 4. clear tests
+# ===========================================================================
+
+class TestClear:
+    def test_clear_calls_init(self, history, mock_file_exists):
+        history.clear()
+        mock_file_exists.assert_called_once()
+        cmd = mock_file_exists.call_args[0][0]
+        assert cmd == ["ate", "memory", "init", "--path", "/tmp/test.mv2"]
+
+    def test_clear_reinitialises_file(self, history, mock_file_exists):
+        """After clear, messages should be empty (given fresh init)."""
+        history.clear()
+        # Next export returns empty
+        mock_file_exists.return_value = _completed_process(stdout="[]")
+        assert history.messages == []
+
+
+# ===========================================================================
+# 5. Error handling tests
+# ===========================================================================
+
+class TestErrorHandling:
+    def test_timeout_raises_runtime_error(self, history, mock_file_exists):
+        mock_file_exists.side_effect = subprocess.TimeoutExpired(cmd="ate", timeout=30)
+        with pytest.raises(RuntimeError, match="timed out"):
+            history.messages
+
+    def test_file_not_found_raises_runtime_error(self, history, mock_file_exists):
+        mock_file_exists.side_effect = FileNotFoundError("ate not found")
+        with pytest.raises(RuntimeError, match="not found"):
+            history.messages
+
+    def test_non_zero_exit_add_logs_warning(self, history, mock_file_exists, caplog):
+        mock_file_exists.return_value = subprocess.CompletedProcess(
+            args=[], returncode=1, stdout="", stderr="some error"
+        )
+        import logging
+        with caplog.at_level(logging.WARNING):
+            history.add_message(HumanMessage(content="x"))
+        assert "non-zero" in caplog.text.lower() or "exit code" in caplog.text.lower()
+
+
+# ===========================================================================
+# 6. Session isolation tests
+# ===========================================================================
+
+class TestSessionIsolation:
+    def test_different_sessions_see_own_messages(self, mock_file_exists):
+        h1 = AteChatMessageHistory(session_id="s1", memory_path="/tmp/shared.mv2")
+        h2 = AteChatMessageHistory(session_id="s2", memory_path="/tmp/shared.mv2")
+
+        entries = [
+            _make_memory_entry(HumanMessage(content="from s1"), "s1", "m1"),
+            _make_memory_entry(HumanMessage(content="from s2"), "s2", "m2"),
+        ]
+        mock_file_exists.return_value = _completed_process(
+            stdout=_make_export_json(entries)
+        )
+
+        msgs1 = h1.messages
+        assert len(msgs1) == 1
+        assert msgs1[0].content == "from s1"
+
+        msgs2 = h2.messages
+        assert len(msgs2) == 1
+        assert msgs2[0].content == "from s2"
+
+    def test_session_with_no_matching_messages(self, mock_file_exists):
+        h = AteChatMessageHistory(session_id="lonely", memory_path="/tmp/x.mv2")
+        entries = [
+            _make_memory_entry(HumanMessage(content="nope"), "other", "m1"),
+        ]
+        mock_file_exists.return_value = _completed_process(
+            stdout=_make_export_json(entries)
+        )
+        assert h.messages == []
+
+
+# ===========================================================================
+# 7. Edge cases & misc
+# ===========================================================================
+
+class TestEdgeCases:
+    def test_message_with_special_characters(self, history, mock_file_exists):
+        msg = HumanMessage(content='Hello "world" \n\ttab & <html>')
+        history.add_message(msg)
+        cmd = mock_file_exists.call_args[0][0]
+        text_idx = cmd.index("--text") + 1
+        parsed = json.loads(cmd[text_idx])
+        assert parsed["data"]["content"] == 'Hello "world" \n\ttab & <html>'
+
+    def test_message_with_unicode(self, history, mock_file_exists):
+        msg = HumanMessage(content="こんにちは 🌍")
+        history.add_message(msg)
+        cmd = mock_file_exists.call_args[0][0]
+        text_idx = cmd.index("--text") + 1
+        parsed = json.loads(cmd[text_idx])
+        assert parsed["data"]["content"] == "こんにちは 🌍"
+
+    def test_whitespace_only_export(self, history, mock_file_exists):
+        mock_file_exists.return_value = _completed_process(stdout="   \n  ")
+        assert history.messages == []
+
+    def test_entry_missing_tags_key(self, history, mock_file_exists):
+        entry = {"id": "m1", "text": json.dumps(message_to_dict(HumanMessage(content="x")))}
+        # No "tags" key — should not match any session
+        mock_file_exists.return_value = _completed_process(
+            stdout=_make_export_json([entry])
+        )
+        assert history.messages == []
+
+    def test_empty_tags_list(self, history, mock_file_exists):
+        entry = {
+            "id": "m1",
+            "text": json.dumps(message_to_dict(HumanMessage(content="x"))),
+            "tags": [],
+        }
+        mock_file_exists.return_value = _completed_process(
+            stdout=_make_export_json([entry])
+        )
+        assert history.messages == []

--- a/libs/community/tests/unit_tests/chat_message_histories/test_imports.py
+++ b/libs/community/tests/unit_tests/chat_message_histories/test_imports.py
@@ -1,6 +1,7 @@
 from langchain_community.chat_message_histories import __all__, _module_lookup
 
 EXPECTED_ALL = [
+    "AteChatMessageHistory",
     "AstraDBChatMessageHistory",
     "CassandraChatMessageHistory",
     "ChatMessageHistory",


### PR DESCRIPTION
## Summary

Adds `AteChatMessageHistory`, a `BaseChatMessageHistory` backend powered by [FoodForThought's **ate** CLI](https://kindly.fyi/foodforthought) and the `.mv2` portable memory format.

## What it does

Stores LangChain chat messages in a `.mv2` memory file via the `ate` CLI. Each message is serialised as a tagged memory entry, enabling session-multiplexed storage in a single file.

## How it differs from `FileChatMessageHistory`

| Feature | FileChatMessageHistory | AteChatMessageHistory |
|---|---|---|
| Storage format | Plain JSON | `.mv2` (semantic, tagged) |
| Semantic search | ❌ | ✅ via `ate memory search` |
| Encryption at rest | ❌ | ✅ AES-256 |
| Multi-agent access | ❌ (no locking) | ✅ file-level locking |
| Tagged memories | ❌ | ✅ arbitrary key:value tags |
| Session multiplexing | ❌ one file = one history | ✅ many sessions per file |

## Installation

```bash
# Install ate CLI
pip install ate-memory
# or
brew install ate-cli
```

## Usage

```python
from langchain_community.chat_message_histories import AteChatMessageHistory

history = AteChatMessageHistory(
    session_id="user-42",
    memory_path="./conversations.mv2",
)

history.add_user_message("What's the weather?")
history.add_ai_message("Sunny and 72°F!")

# Use with RunnableWithMessageHistory
from langchain_core.runnables.history import RunnableWithMessageHistory

chain_with_history = RunnableWithMessageHistory(
    your_chain,
    lambda session_id: AteChatMessageHistory(
        session_id=session_id,
        memory_path="./chat.mv2",
    ),
)
```

## Tests

**39 unit tests** covering:
- Constructor validation (8 tests)
- `messages` property — export, filtering, parsing, edge cases (11 tests)
- `add_message` — serialisation, tags, format (8 tests)
- `clear` — reinitialisation (2 tests)
- Error handling — timeouts, missing CLI, non-zero exits (3 tests)
- Session isolation (2 tests)
- Edge cases — unicode, special chars, malformed data (5 tests)

All subprocess and `shutil.which` calls are fully mocked — no real CLI required.

## Files changed

- `libs/community/langchain_community/chat_message_histories/ate.py` — implementation
- `libs/community/langchain_community/chat_message_histories/__init__.py` — registration
- `libs/community/tests/unit_tests/chat_message_histories/test_ate_chat_message_history.py` — tests
- `libs/community/tests/unit_tests/chat_message_histories/test_imports.py` — updated expected imports

## Links

- [ate CLI docs](https://kindly.fyi/foodforthought)
- [.mv2 format specification](https://kindly.fyi/foodforthought)
