### PR TITLE
fix(utilities): add backward compatible import for serpapi GoogleSearch

### DIFF
--- a/libs/community/langchain_community/utilities/serpapi.py
+++ b/libs/community/langchain_community/utilities/serpapi.py
@@ -69,14 +69,16 @@ class SerpAPIWrapper(BaseModel):
         )
         values["serpapi_api_key"] = serpapi_api_key
         try:
-            from serpapi import GoogleSearch
-
-            values["search_engine"] = GoogleSearch
+            from serpapi.google_search import GoogleSearch
         except ImportError:
-            raise ImportError(
-                "Could not import serpapi python package. "
-                "Please install it with `pip install google-search-results`."
-            )
+            try:
+                from serpapi import GoogleSearch
+            except ImportError:
+                raise ImportError(
+                    "Could not import serpapi python package. "
+                    "Please install it with `pip install google-search-results`."
+                )
+        values["search_engine"] = GoogleSearch
         return values
 
     async def arun(self, query: str, **kwargs: Any) -> str:


### PR DESCRIPTION
**Description:** Updates the serpapi import to support both the new and old package import paths. The new `google-search-results` package changed the import from `from serpapi import GoogleSearch` to `from serpapi.google_search import GoogleSearch`. This change tries the new import first and falls back to the old import for backward compatibility.

**Issue:** N/A

**Dependencies:** None