### PR TITLE
Update openai.py

### DIFF
--- a/libs/community/langchain_community/chat_models/openai.py
+++ b/libs/community/langchain_community/chat_models/openai.py
@@ -153,7 +153,7 @@ def _update_token_usage(
 ) -> Union[int, dict]:
     # Token usage is either ints or dictionaries
     # `reasoning_tokens` is nested inside `completion_tokens_details`
-    if isinstance(new_usage, int):
+    if isinstance(new_usage, int):mm                    
         if not isinstance(overall_token_usage, int):
             raise ValueError(
                 f"Got different types for token usage: "
@@ -276,6 +276,17 @@ class ChatOpenAI(BaseChatModel):
     model_config = ConfigDict(
         populate_by_name=True,
     )
+
+        def __repr__(self) -> str:
+        """Safe string representation that avoids leaking API keys."""
+        masked_key = "***" if self.openai_api_key else None
+        return (
+            f"ChatOpenAI("
+            f"model_name={self.model_name!r}, "
+            f"openai_api_key={masked_key}, "
+            f"openai_proxy={self.openai_proxy!r})"
+        )
+
 
     @model_validator(mode="before")
     @classmethod


### PR DESCRIPTION

- [ ] **PR title**: fix(community): mask openai_api_key in ChatOpenAI.__repr__to_prevent_leakage


- [ ] **PR message**: 
  - **Description:** This PR prevents accidental leakage of OpenAI API keys when printing or logging
`ChatOpenAI` instances by overriding `__repr__` to mask the `openai_api_key`
field.

This affects common usage patterns such as:

- `print(llm)`
- logging model objects
- debugging in notebooks or error traces

- [ ] **Lint and test**: 
- [ ] current version of code-
```
from langchain_community.chat_models import ChatOpenAI

llm = ChatOpenAI(api_key="FAKEKEY123", model="gpt-4o")
print(llm)

```




- Current version output:


```
lm = ChatOpenAI(api_key="FAKEKEY123", model="gpt-4o")
client=<openai.resources.chat.completions.completions.Completions object at 0x7593c05cee40> async_client=<openai.resources.chat.completions.completions.AsyncCompletions object at 0x7593c05cf8c0> model_name='gpt-4o' model_kwargs={} openai_api_key='FAKEKEY123' openai_proxy=''
```





- After Fix via this:



  ```
  def __repr__(self) -> str:
        """Safe string representation that avoids leaking API keys."""
        masked_key = "***" if self.openai_api_key else None
        return (
            f"ChatOpenAI("
            f"model_name={self.model_name!r}, "
            f"openai_api_key={masked_key}, "
            f"openai_proxy={self.openai_proxy!r})"
        )
```


### OUTPUT->    ChatOpenAI(model_name='gpt-4o', openai_api_key='***', openai_proxy='')
