### PR TITLE
feat(you): update Search/Contents APIs to v1 and add Research API

### DIFF
--- a/libs/community/langchain_community/llms/you.py
+++ b/libs/community/langchain_community/llms/you.py
@@ -72,10 +72,10 @@ class You(LLM):
     - Cites the specific web page snippet relevant to the claim
 
     To connect to the You.com api requires an API key which
-    you can get at https://api.you.com.
+    you can get at https://you.com/platform.
 
     For more information, check out the documentations at
-    https://documentation.you.com/api-reference/.
+    https://docs.you.com/api-reference/.
 
     Args:
         endpoint: You.com conversational endpoints. Choose from "smart" or "research"
@@ -90,7 +90,7 @@ class You(LLM):
     )
     ydc_api_key: Optional[str] = Field(
         None,
-        description="You.com API key, if `YDC_API_KEY` is not set in the envrioment",
+        description="You.com API key, if `YDC_API_KEY` is not set in the environment",
     )
 
     def _call(

--- a/libs/community/langchain_community/retrievers/you.py
+++ b/libs/community/langchain_community/retrievers/you.py
@@ -13,8 +13,20 @@ from langchain_community.utilities import YouSearchAPIWrapper
 class YouRetriever(BaseRetriever, YouSearchAPIWrapper):
     """You.com Search API retriever.
 
-    It wraps results() to get_relevant_documents
-    It uses all YouSearchAPIWrapper arguments without any change.
+    Wraps ``YouSearchAPIWrapper`` to provide a LangChain retriever interface.
+    Accepts all ``YouSearchAPIWrapper`` arguments.
+
+    Setup:
+        Set the ``YDC_API_KEY`` environment variable or pass ``ydc_api_key``
+        directly.
+
+    Example:
+        .. code-block:: python
+
+            from langchain_community.retrievers import YouRetriever
+
+            retriever = YouRetriever()
+            docs = retriever.invoke("latest AI news")
     """
 
     def _get_relevant_documents(
@@ -24,7 +36,7 @@ class YouRetriever(BaseRetriever, YouSearchAPIWrapper):
         run_manager: CallbackManagerForRetrieverRun,
         **kwargs: Any,
     ) -> List[Document]:
-        return self.results(query, run_manager=run_manager.get_child(), **kwargs)
+        return self.results(query, **kwargs)
 
     async def _aget_relevant_documents(
         self,
@@ -33,7 +45,4 @@ class YouRetriever(BaseRetriever, YouSearchAPIWrapper):
         run_manager: AsyncCallbackManagerForRetrieverRun,
         **kwargs: Any,
     ) -> List[Document]:
-        results = await self.results_async(
-            query, run_manager=run_manager.get_child(), **kwargs
-        )
-        return results
+        return await self.results_async(query, **kwargs)

--- a/libs/community/langchain_community/tools/__init__.py
+++ b/libs/community/langchain_community/tools/__init__.py
@@ -324,6 +324,7 @@ if TYPE_CHECKING:
         YahooFinanceNewsTool,
     )
     from langchain_community.tools.you.tool import (
+        YouContentsTool,
         YouSearchTool,
     )
     from langchain_community.tools.youtube.search import (
@@ -478,6 +479,7 @@ __all__ = [
     "WolframAlphaQueryRun",
     "WriteFileTool",
     "YahooFinanceNewsTool",
+    "YouContentsTool",
     "YouSearchTool",
     "YouTubeSearchTool",
     "ZapierNLAListActions",
@@ -632,6 +634,7 @@ _module_lookup = {
     "WolframAlphaQueryRun": "langchain_community.tools.wolfram_alpha.tool",
     "WriteFileTool": "langchain_community.tools.file_management",
     "YahooFinanceNewsTool": "langchain_community.tools.yahoo_finance_news",
+    "YouContentsTool": "langchain_community.tools.you.tool",
     "YouSearchTool": "langchain_community.tools.you.tool",
     "YouTubeSearchTool": "langchain_community.tools.youtube.search",
     "ZapierNLAListActions": "langchain_community.tools.zapier.tool",

--- a/libs/community/langchain_community/tools/you/__init__.py
+++ b/libs/community/langchain_community/tools/you/__init__.py
@@ -1,7 +1,13 @@
 """You.com API toolkit."""
 
-from langchain_community.tools.you.tool import YouSearchTool
+from langchain_community.tools.you.tool import (
+    YouContentsTool,
+    YouResearchTool,
+    YouSearchTool,
+)
 
 __all__ = [
+    "YouContentsTool",
+    "YouResearchTool",
     "YouSearchTool",
 ]

--- a/libs/community/langchain_community/tools/you/tool.py
+++ b/libs/community/langchain_community/tools/you/tool.py
@@ -11,21 +11,85 @@ from pydantic import BaseModel, Field
 from langchain_community.utilities.you import YouSearchAPIWrapper
 
 
-class YouInput(BaseModel):
-    """Input schema for the you.com tool."""
+class YouSearchInput(BaseModel):
+    """Input schema for You.com search."""
 
-    query: str = Field(description="should be a search query")
+    query: str = Field(description="Search query")
+
+
+YouInput = YouSearchInput
 
 
 class YouSearchTool(BaseTool):
-    """Tool that searches the you.com API."""
+    """Tool that searches the web using the You.com Search API.
+
+    Setup:
+        Set the ``YDC_API_KEY`` environment variable.
+
+        .. code-block:: bash
+
+            export YDC_API_KEY="your-api-key"
+
+    Instantiate:
+
+        .. code-block:: python
+
+            from langchain_community.tools.you import YouSearchTool
+            from langchain_community.utilities.you import YouSearchAPIWrapper
+
+            tool = YouSearchTool(
+                api_wrapper=YouSearchAPIWrapper(
+                    count=5,
+                    # livecrawl="web",  # fetch full page content
+                    # freshness="week",  # restrict by recency
+                )
+            )
+
+    Invoke directly with args:
+
+        .. code-block:: python
+
+            tool.invoke({'query': 'latest AI research'})
+
+        .. code-block:: python
+
+            [
+                Document(
+                    page_content="Researchers have developed ...",
+                    metadata={
+                        "url": "https://example.com/ai-research",
+                        "title": "Latest AI Research Breakthroughs",
+                        "description": "A summary of recent advances ...",
+                        "thumbnail_url": "https://example.com/thumb.jpg",
+                        "favicon_url": "https://example.com/favicon.ico",
+                        "page_age": "2025-01-15T00:00:00",
+                    },
+                ),
+                ...
+            ]
+
+    Invoke with tool call:
+
+        .. code-block:: python
+
+            tool.invoke({"args": {"query": "latest AI research"}, "type": "tool_call", "id": "1", "name": "you_search"})
+
+        .. code-block:: python
+
+            ToolMessage(
+                content="[Document(metadata={'url': 'https://example.com/ai-research', 'title': 'Latest AI Research Breakthroughs', ...}, page_content='Researchers have developed ...'), ...]",
+                tool_call_id="1",
+                name="you_search",
+            )
+
+    """  # noqa: E501
 
     name: str = "you_search"
     description: str = (
-        "The YOU APIs make LLMs and search experiences more factual and"
-        "up to date with realtime web data."
+        "Search the web using You.com's Search API. Returns factual, "
+        "up-to-date web results with snippets and metadata."
     )
-    args_schema: Type[BaseModel] = YouInput
+    args_schema: Type[BaseModel] = YouSearchInput
     api_wrapper: YouSearchAPIWrapper = Field(default_factory=YouSearchAPIWrapper)
 
     def _run(
@@ -33,7 +97,7 @@ class YouSearchTool(BaseTool):
         query: str,
         run_manager: Optional[CallbackManagerForToolRun] = None,
     ) -> List[Document]:
-        """Use the you.com tool."""
+        """Use the You.com search tool."""
         return self.api_wrapper.results(query)
 
     async def _arun(
@@ -41,5 +105,176 @@ class YouSearchTool(BaseTool):
         query: str,
         run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
     ) -> List[Document]:
-        """Use the you.com tool asynchronously."""
+        """Use the You.com search tool asynchronously."""
         return await self.api_wrapper.results_async(query)
+
+
+class YouResearchInput(BaseModel):
+    """Input schema for You.com research."""
+
+    query: str = Field(description="Research question or complex query to investigate")
+
+
+class YouResearchTool(BaseTool):
+    """Tool that researches a topic using the You.com Research API.
+
+    Returns a comprehensive, cited answer with multi-step reasoning.
+
+    Setup:
+        Set the ``YDC_API_KEY`` environment variable.
+
+        .. code-block:: bash
+
+            export YDC_API_KEY="your-api-key"
+
+    Instantiate:
+
+        .. code-block:: python
+
+            from langchain_community.tools.you import YouResearchTool
+            from langchain_community.utilities.you import YouSearchAPIWrapper
+
+            tool = YouResearchTool(
+                api_wrapper=YouSearchAPIWrapper(
+                    research_effort="standard",  # lite, standard, deep, exhaustive
+                )
+            )
+
+    Invoke directly with args:
+
+        .. code-block:: python
+
+            tool.invoke("what are the latest advances in quantum computing")
+
+        .. code-block:: python
+
+            "Quantum computing has seen significant advances...\n\n## Sources\n\n1. [Nature](https://nature.com/...)"
+
+    Invoke with tool call:
+
+        .. code-block:: python
+
+            tool.invoke({"args": {"query": "quantum computing advances"}, "type": "tool_call", "id": "1", "name": "you_research"})
+
+        .. code-block:: python
+
+            ToolMessage(
+                content="Quantum computing has seen...",
+                tool_call_id="1",
+                name="you_research",
+            )
+
+    """  # noqa: E501
+
+    name: str = "you_research"
+    description: str = (
+        "Research a topic in depth using You.com's Research API. Returns a "
+        "comprehensive answer with inline citations and a list of sources. "
+        "Best for complex questions that benefit from multi-step reasoning."
+    )
+    args_schema: Type[BaseModel] = YouResearchInput
+    api_wrapper: YouSearchAPIWrapper = Field(default_factory=YouSearchAPIWrapper)
+
+    def _run(
+        self,
+        query: str,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Research the query using the You.com Research API."""
+        return self.api_wrapper.research_text(query)
+
+    async def _arun(
+        self,
+        query: str,
+        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
+    ) -> str:
+        """Research the query using the You.com Research API asynchronously."""
+        return await self.api_wrapper.research_text_async(query)
+
+
+class YouContentsInput(BaseModel):
+    """Input schema for You.com contents extraction."""
+
+    urls: List[str] = Field(description="URLs to fetch content from")
+
+
+class YouContentsTool(BaseTool):
+    """Tool that fetches clean page content via the You.com Contents API.
+
+    Setup:
+        Set the ``YDC_API_KEY`` environment variable.
+
+        .. code-block:: bash
+
+            export YDC_API_KEY="your-api-key"
+
+    Instantiate:
+
+        .. code-block:: python
+
+            from langchain_community.tools.you import YouContentsTool
+            from langchain_community.utilities.you import YouSearchAPIWrapper
+
+            tool = YouContentsTool(
+                api_wrapper=YouSearchAPIWrapper()
+            )
+
+    Invoke directly with args:
+
+        .. code-block:: python
+
+            tool.invoke({'urls': ['https://example.com']})
+
+        .. code-block:: python
+
+            [
+                Document(
+                    page_content="# Example Domain\n\nThis domain is for use in illustrative examples ...",
+                    metadata={
+                        "url": "https://example.com",
+                        "title": "Example Domain",
+                        "site_name": "Example",
+                        "favicon_url": "https://example.com/favicon.ico",
+                    },
+                )
+            ]
+
+    Invoke with tool call:
+
+        .. code-block:: python
+
+            tool.invoke({"args": {"urls": ["https://example.com"]}, "type": "tool_call", "id": "1", "name": "you_contents"})
+
+        .. code-block:: python
+
+            ToolMessage(
+                content="[Document(metadata={'url': 'https://example.com', 'title': 'Example Domain', ...}, page_content='# Example Domain\n\nThis domain is for use in ...')]",
+                tool_call_id="1",
+                name="you_contents",
+            )
+
+    """  # noqa: E501
+
+    name: str = "you_contents"
+    description: str = (
+        "Fetch clean HTML or Markdown content from web pages using "
+        "You.com's Contents API. Useful for extracting readable page content."
+    )
+    args_schema: Type[BaseModel] = YouContentsInput
+    api_wrapper: YouSearchAPIWrapper = Field(default_factory=YouSearchAPIWrapper)
+
+    def _run(
+        self,
+        urls: List[str],
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> List[Document]:
+        """Fetch page content using the You.com Contents API."""
+        return self.api_wrapper.contents(urls)
+
+    async def _arun(
+        self,
+        urls: List[str],
+        run_manager: Optional[AsyncCallbackManagerForToolRun] = None,
+    ) -> List[Document]:
+        """Fetch page content asynchronously using the You.com Contents API."""
+        return await self.api_wrapper.contents_async(urls)

--- a/libs/community/langchain_community/utilities/you.py
+++ b/libs/community/langchain_community/utilities/you.py
@@ -1,7 +1,7 @@
-"""Util that calls you.com Search API.
+"""Wrapper for You.com Search, Contents, and Research APIs.
 
-In order to set this up, follow instructions at:
-https://documentation.you.com/quickstart
+For setup instructions and API key, visit:
+https://docs.you.com/get-started/quickstart
 """
 
 import warnings
@@ -11,101 +11,74 @@ import aiohttp
 import requests
 from langchain_core.documents import Document
 from langchain_core.utils import get_from_dict_or_env
-from pydantic import BaseModel, Field, model_validator
+from pydantic import BaseModel, model_validator
 from typing_extensions import Self
 
-YOU_API_URL = "https://api.ydc-index.io"
+YOU_SEARCH_API_URL = "https://ydc-index.io"
+YOU_RESEARCH_API_URL = "https://api.you.com"
 
-
-class YouHitMetadata(BaseModel):
-    """Metadata on a single hit from you.com"""
-
-    title: str = Field(description="The title of the result")
-    url: str = Field(description="The url of the result")
-    thumbnail_url: str = Field(description="Thumbnail associated with the result")
-    description: str = Field(description="Details about the result")
-
-
-class YouHit(YouHitMetadata):
-    """A single hit from you.com, which may contain multiple snippets"""
-
-    snippets: List[str] = Field(description="One or snippets of text")
-
-
-class YouAPIOutput(BaseModel):
-    """Output from you.com API."""
-
-    hits: List[YouHit] = Field(
-        description="A list of dictionaries containing the results"
-    )
-
-
-class YouDocument(BaseModel):
-    """Output of parsing one snippet."""
-
-    page_content: str = Field(description="One snippet of text")
-    metadata: YouHitMetadata
+# Sent in User-Agent so You.com can identify langchain-community traffic.
+YOU_LANGCHAIN_USER_AGENT = "langchain-community-you"
 
 
 class YouSearchAPIWrapper(BaseModel):
-    """Wrapper for you.com Search and News API.
+    """Wrapper for You.com Search, Contents, and Research APIs.
 
-    To connect to the You.com api requires an API key which
-    you can get at https://api.you.com.
-    You can check out the docs at https://documentation.you.com/api-reference/.
+    To connect to the You.com API requires an API key which
+    you can get at https://you.com/platform.
+    You can check out the docs at https://docs.you.com/api-reference/.
 
-    You need to set the environment variable `YDC_API_KEY` for retriever to operate.
+    You need to set the environment variable ``YDC_API_KEY`` for the wrapper
+    to operate.
 
-    Attributes
-    ----------
-    ydc_api_key: str, optional
-        you.com api key, if YDC_API_KEY is not set in the environment
-    endpoint_type: str, optional
-        you.com endpoints: search, news, rag;
-        `web` and `snippet` alias `search`
-        `rag` returns `{'message': 'Forbidden'}`
-        @todo `news` endpoint
-    num_web_results: int, optional
-        The max number of web results to return, must be under 20.
-        This is mapped to the `count` query parameter for the News API.
-    safesearch: str, optional
-        Safesearch settings, one of off, moderate, strict, defaults to moderate
-    country: str, optional
-        Country code, ex: 'US' for United States, see api docs for list
-    search_lang: str, optional
-        (News API) Language codes, ex: 'en' for English, see api docs for list
-    ui_lang: str, optional
-        (News API) User interface language for the response, ex: 'en' for English,
-                   see api docs for list
-    spellcheck: bool, optional
-        (News API) Whether to spell check query or not, defaults to True
-    k: int, optional
-        max number of Documents to return using `results()`
-    n_hits: int, optional, deprecated
-        Alias for num_web_results
-    n_snippets_per_hit: int, optional
-        limit the number of snippets returned per hit
+    Attributes:
+        ydc_api_key: You.com API key. If not set, reads from ``YDC_API_KEY``
+            env var.
+        endpoint_type: Determines which results to parse from the unified search
+            response. ``"search"`` parses web results, ``"news"`` parses news
+            results (deprecated: news is now served through the search endpoint).
+        count: Maximum number of results per section (web/news). Defaults to 10.
+        safesearch: Content filter level: ``"off"``, ``"moderate"``, or
+            ``"strict"``.
+        country: Country code for geographic focus (e.g. ``"US"``).
+        freshness: Restrict results by recency. One of ``"day"``, ``"week"``,
+            ``"month"``, ``"year"``, or a date range
+            ``"YYYY-MM-DDtoYYYY-MM-DD"``.
+        offset: Pagination offset (0--9). Results offset by ``count * offset``.
+        livecrawl: Which sections to livecrawl for full page content:
+            ``"web"``, ``"news"``, or ``"all"``.
+        livecrawl_formats: Format of livecrawled content: ``"html"`` or
+            ``"markdown"``.
+        language: Language of results to return (BCP 47 format, e.g. ``"en"``).
+            Defaults to ``"en"`` if not set.
+        k: Maximum number of Documents to return from ``results()``.
+        n_snippets_per_hit: Limit snippets returned per hit.
     """
 
     ydc_api_key: Optional[str] = None
 
-    # @todo deprecate `snippet`, not part of API
     endpoint_type: Literal["search", "news", "rag", "snippet"] = "search"
 
-    # Common fields between Search and News API
-    num_web_results: Optional[int] = None
+    # v1 search params
+    count: Optional[int] = None
     safesearch: Optional[Literal["off", "moderate", "strict"]] = None
     country: Optional[str] = None
-
-    # News API specific fields
-    search_lang: Optional[str] = None
-    ui_lang: Optional[str] = None
-    spellcheck: Optional[bool] = None
+    freshness: Optional[str] = None
+    offset: Optional[int] = None
+    livecrawl: Optional[Literal["web", "news", "all"]] = None
+    livecrawl_formats: Optional[Literal["html", "markdown"]] = None
+    language: Optional[str] = None
 
     k: Optional[int] = None
     n_snippets_per_hit: Optional[int] = None
-    # should deprecate n_hits
+    research_effort: Optional[Literal["lite", "standard", "deep", "exhaustive"]] = None
+
+    # Deprecated fields kept for backwards compat
+    num_web_results: Optional[int] = None
     n_hits: Optional[int] = None
+    search_lang: Optional[str] = None
+    ui_lang: Optional[str] = None
+    spellcheck: Optional[bool] = None
 
     @model_validator(mode="before")
     @classmethod
@@ -117,107 +90,140 @@ class YouSearchAPIWrapper(BaseModel):
         return values
 
     @model_validator(mode="after")
-    def warn_if_set_fields_have_no_effect(self) -> Self:
-        if self.endpoint_type != "news":
-            news_api_fields = ("search_lang", "ui_lang", "spellcheck")
-            for field in news_api_fields:
-                if getattr(self, field):
-                    warnings.warn(
-                        (
-                            f"News API-specific field '{field}' is set but "
-                            f'`endpoint_type="{self.endpoint_type}"`. '
-                            "This will have no effect."
-                        ),
-                        UserWarning,
-                    )
-        if self.endpoint_type not in ("search", "snippet"):
-            if self.n_snippets_per_hit:
-                warnings.warn(
-                    (
-                        "Field 'n_snippets_per_hit' only has effect on "
-                        '`endpoint_type="search"`.'
-                    ),
-                    UserWarning,
-                )
-        return self
-
-    @model_validator(mode="after")
-    def warn_if_deprecated_endpoints_are_used(self) -> Self:
-        if self.endpoint_type == "snippets":
+    def _warn_deprecated_fields(self) -> Self:
+        if self.num_web_results is not None:
             warnings.warn(
-                (
-                    f'`endpoint_type="{self.endpoint_type}"` is deprecated. '
-                    'Use `endpoint_type="search"` instead.'
-                ),
+                "`num_web_results` is deprecated. Use `count` instead.",
                 DeprecationWarning,
+                stacklevel=2,
+            )
+            if self.count is None:
+                self.count = self.num_web_results
+        if self.n_hits is not None:
+            warnings.warn(
+                "`n_hits` is deprecated and has no effect.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        for field_name in ("search_lang", "ui_lang", "spellcheck"):
+            if getattr(self, field_name) is not None:
+                warnings.warn(
+                    f"`{field_name}` is deprecated and has no effect.",
+                    DeprecationWarning,
+                    stacklevel=2,
+                )
+        if self.endpoint_type == "news":
+            warnings.warn(
+                '`endpoint_type="news"` is deprecated. Use '
+                '`endpoint_type="search"` and read news from '
+                "`results.news` instead.",
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if self.endpoint_type == "rag":
+            warnings.warn(
+                '`endpoint_type="rag"` is deprecated and returns Forbidden.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if self.endpoint_type == "snippet":
+            warnings.warn(
+                '`endpoint_type="snippet"` is deprecated. '
+                'Use `endpoint_type="search"` instead.',
+                DeprecationWarning,
+                stacklevel=2,
+            )
+        if self.endpoint_type not in ("search", "snippet") and self.n_snippets_per_hit:
+            warnings.warn(
+                ("'n_snippets_per_hit' only has effect on `endpoint_type=\"search\"`."),
+                UserWarning,
+                stacklevel=2,
             )
         return self
 
-    def _generate_params(self, query: str, **kwargs: Any) -> Dict:
-        """
-        Parse parameters required for different You.com APIs.
-
-        Args:
-            query: The query to search for.
-        """
-        params = {
-            "safesearch": self.safesearch,
-            "country": self.country,
-            **kwargs,
+    def _get_headers(self) -> Dict[str, str]:
+        """Build headers for API requests."""
+        return {
+            "X-API-Key": self.ydc_api_key or "",
+            "User-Agent": YOU_LANGCHAIN_USER_AGENT,
         }
 
-        # Add endpoint-specific params
-        if self.endpoint_type in ("search", "snippet"):
-            params.update(
-                query=query,
-                num_web_results=self.num_web_results,
-            )
-        elif self.endpoint_type == "news":
-            params.update(
-                q=query,
-                count=self.num_web_results,
-                search_lang=self.search_lang,
-                ui_lang=self.ui_lang,
-                spellcheck=self.spellcheck,
-            )
+    def _generate_params(self, query: str, **kwargs: Any) -> Dict:
+        """Build query parameters for the v1/search endpoint.
 
-        params = {k: v for k, v in params.items() if v is not None}
-        return params
+        Args:
+            query: The search query.
+
+        Returns:
+            Dict of non-None query parameters.
+        """
+        params: Dict[str, Any] = {
+            "query": query,
+            "count": self.count,
+            "safesearch": self.safesearch,
+            "country": self.country,
+            "freshness": self.freshness,
+            "offset": self.offset,
+            "livecrawl": self.livecrawl,
+            "livecrawl_formats": self.livecrawl_formats,
+            "language": self.language,
+            **kwargs,
+        }
+        return {k: v for k, v in params.items() if v is not None}
 
     def _parse_results(self, raw_search_results: Dict) -> List[Document]:
-        """
-        Extracts snippets from each hit and puts them in a Document
-        Parameters:
-            raw_search_results: A dict containing list of hits
-        Returns:
-            List[YouDocument]: A dictionary of parsed results
-        """
+        """Extract Documents from the v1/search response.
 
-        # return news results
-        if self.endpoint_type == "news":
-            news_results = raw_search_results["news"]["results"]
+        For ``endpoint_type="news"``, parses ``results.news``.
+        For web results, prefers livecrawl ``contents`` (markdown then html)
+        when available, falling back to ``snippets``.
+
+        Args:
+            raw_search_results: Raw JSON response from the search API.
+
+        Returns:
+            List of Documents with page content and metadata.
+        """
+        endpoint = "search" if self.endpoint_type == "snippet" else self.endpoint_type
+        results = raw_search_results.get("results", {})
+
+        if endpoint == "news":
+            news_results = results.get("news", [])
             if self.k is not None:
                 news_results = news_results[: self.k]
-            return [
-                Document(page_content=result["description"], metadata=result)
-                for result in news_results
-            ]
+            docs = []
+            for result in news_results:
+                contents = result.get("contents") or {}
+                page_content = (
+                    contents.get("markdown")
+                    or contents.get("html")
+                    or result.get("description", "")
+                )
+                docs.append(Document(page_content=page_content, metadata=result))
+            return docs
 
         docs = []
-        for hit in raw_search_results["hits"]:
-            n_snippets_per_hit = self.n_snippets_per_hit or len(hit.get("snippets"))
-            for snippet in hit.get("snippets")[:n_snippets_per_hit]:
-                docs.append(
-                    Document(
-                        page_content=snippet,
-                        metadata={
-                            "url": hit.get("url"),
-                            "thumbnail_url": hit.get("thumbnail_url"),
-                            "title": hit.get("title"),
-                            "description": hit.get("description"),
-                        },
-                    )
-                )
+        for hit in results.get("web", []):
+            meta = {
+                "url": hit.get("url"),
+                "thumbnail_url": hit.get("thumbnail_url"),
+                "title": hit.get("title"),
+                "description": hit.get("description"),
+                "favicon_url": hit.get("favicon_url"),
+                "page_age": hit.get("page_age"),
+            }
+
+            contents = hit.get("contents") or {}
+            livecrawl_content = contents.get("markdown") or contents.get("html")
+            if livecrawl_content:
+                docs.append(Document(page_content=livecrawl_content, metadata=meta))
+                if self.k is not None and len(docs) >= self.k:
+                    return docs
+                continue
+
+            n_snippets = self.n_snippets_per_hit or len(hit.get("snippets", []))
+            for snippet in hit.get("snippets", [])[:n_snippets]:
+                docs.append(Document(page_content=snippet, metadata=dict(meta)))
                 if self.k is not None and len(docs) >= self.k:
                     return docs
         return docs
@@ -227,20 +233,18 @@ class YouSearchAPIWrapper(BaseModel):
         query: str,
         **kwargs: Any,
     ) -> Dict:
-        """Run query through you.com Search and return hits.
+        """Run query through You.com Search and return the raw JSON response.
 
         Args:
             query: The query to search for.
-        Returns: YouAPIOutput
-        """
-        headers = {"X-API-Key": self.ydc_api_key or ""}
-        params = self._generate_params(query, **kwargs)
 
-        # @todo deprecate `snippet`, not part of API
-        if self.endpoint_type == "snippet":
-            self.endpoint_type = "search"
+        Returns:
+            Raw API response dict.
+        """
+        headers = self._get_headers()
+        params = self._generate_params(query, **kwargs)
         response = requests.get(
-            f"{YOU_API_URL}/{self.endpoint_type}",
+            f"{YOU_SEARCH_API_URL}/v1/search",
             params=params,
             headers=headers,
         )
@@ -252,8 +256,7 @@ class YouSearchAPIWrapper(BaseModel):
         query: str,
         **kwargs: Any,
     ) -> List[Document]:
-        """Run query through you.com Search and parses results into Documents."""
-
+        """Run query through You.com Search and return parsed Documents."""
         raw_search_results = self.raw_results(
             query,
             **{key: value for key, value in kwargs.items() if value is not None},
@@ -265,34 +268,202 @@ class YouSearchAPIWrapper(BaseModel):
         query: str,
         **kwargs: Any,
     ) -> Dict:
-        """Get results from the you.com Search API asynchronously."""
-
-        headers = {"X-API-Key": self.ydc_api_key or ""}
+        """Get raw results from the You.com Search API asynchronously."""
+        headers = self._get_headers()
         params = self._generate_params(query, **kwargs)
-
-        # @todo deprecate `snippet`, not part of API
-        if self.endpoint_type == "snippet":
-            self.endpoint_type = "search"
 
         async with aiohttp.ClientSession() as session:
             async with session.get(
-                url=f"{YOU_API_URL}/{self.endpoint_type}",
+                url=f"{YOU_SEARCH_API_URL}/v1/search",
                 params=params,
                 headers=headers,
-            ) as res:
-                if res.status == 200:
-                    results = await res.json()
-                    return results
-                else:
-                    raise Exception(f"Error {res.status}: {res.reason}")
+            ) as response:
+                response.raise_for_status()
+                return await response.json()
 
     async def results_async(
         self,
         query: str,
         **kwargs: Any,
     ) -> List[Document]:
-        raw_search_results_async = await self.raw_results_async(
+        """Run query through You.com Search asynchronously and return Documents."""
+        raw_search_results = await self.raw_results_async(
             query,
             **{key: value for key, value in kwargs.items() if value is not None},
         )
-        return self._parse_results(raw_search_results_async)
+        return self._parse_results(raw_search_results)
+
+    def contents(
+        self,
+        urls: List[str],
+        formats: Optional[List[Literal["html", "markdown", "metadata"]]] = None,
+        crawl_timeout: Optional[float] = None,
+    ) -> List[Document]:
+        """Fetch clean content from URLs via the You.com Contents API.
+
+        Args:
+            urls: URLs to fetch content from.
+            formats: Content formats to return (``"html"``, ``"markdown"``,
+                ``"metadata"``). Defaults to server default.
+            crawl_timeout: Per-URL crawl timeout in seconds (1--60).
+
+        Returns:
+            List of Documents with page content and metadata.
+        """
+        headers = self._get_headers()
+        body: Dict[str, Any] = {"urls": urls}
+        if formats is not None:
+            body["formats"] = formats
+        if crawl_timeout is not None:
+            body["crawl_timeout"] = crawl_timeout
+
+        response = requests.post(
+            f"{YOU_SEARCH_API_URL}/v1/contents",
+            json=body,
+            headers=headers,
+        )
+        response.raise_for_status()
+        return self._parse_contents_results(response.json())
+
+    async def contents_async(
+        self,
+        urls: List[str],
+        formats: Optional[List[Literal["html", "markdown", "metadata"]]] = None,
+        crawl_timeout: Optional[float] = None,
+    ) -> List[Document]:
+        """Fetch content from URLs asynchronously via the You.com Contents API.
+
+        Args:
+            urls: URLs to fetch content from.
+            formats: Content formats to return.
+            crawl_timeout: Per-URL crawl timeout in seconds (1--60).
+
+        Returns:
+            List of Documents with page content and metadata.
+        """
+        headers = self._get_headers()
+        body: Dict[str, Any] = {"urls": urls}
+        if formats is not None:
+            body["formats"] = formats
+        if crawl_timeout is not None:
+            body["crawl_timeout"] = crawl_timeout
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url=f"{YOU_SEARCH_API_URL}/v1/contents",
+                json=body,
+                headers=headers,
+            ) as response:
+                response.raise_for_status()
+                return self._parse_contents_results(await response.json())
+
+    def raw_research(self, query: str) -> Dict:
+        """Call the You.com Research API and return the raw JSON response.
+
+        Args:
+            query: The research question or complex query.
+
+        Returns:
+            Raw API response dict with ``output.content`` and
+            ``output.sources``.
+        """
+        headers = self._get_headers()
+        body: Dict[str, Any] = {"input": query}
+        if self.research_effort is not None:
+            body["research_effort"] = self.research_effort
+
+        response = requests.post(
+            f"{YOU_RESEARCH_API_URL}/v1/research",
+            json=body,
+            headers=headers,
+        )
+        response.raise_for_status()
+        return response.json()
+
+    def research_text(self, query: str) -> str:
+        """Research a topic and return a formatted markdown answer with sources.
+
+        Args:
+            query: The research question or complex query.
+
+        Returns:
+            Markdown-formatted answer followed by a numbered sources section.
+        """
+        return self._format_research_response(self.raw_research(query))
+
+    async def raw_research_async(self, query: str) -> Dict:
+        """Async variant of :meth:`raw_research`.
+
+        Args:
+            query: The research question or complex query.
+
+        Returns:
+            Raw API response dict with ``output.content`` and
+            ``output.sources``.
+        """
+        headers = self._get_headers()
+        body: Dict[str, Any] = {"input": query}
+        if self.research_effort is not None:
+            body["research_effort"] = self.research_effort
+
+        async with aiohttp.ClientSession() as session:
+            async with session.post(
+                url=f"{YOU_RESEARCH_API_URL}/v1/research",
+                json=body,
+                headers=headers,
+            ) as response:
+                response.raise_for_status()
+                return await response.json()
+
+    async def research_text_async(self, query: str) -> str:
+        """Async variant of :meth:`research_text`.
+
+        Args:
+            query: The research question or complex query.
+
+        Returns:
+            Markdown-formatted answer followed by a numbered sources section.
+        """
+        return self._format_research_response(await self.raw_research_async(query))
+
+    @staticmethod
+    def _format_research_response(raw: Dict) -> str:
+        """Format a raw research API response as markdown with a sources section.
+
+        Args:
+            raw: Raw JSON response dict from ``/v1/research``.
+
+        Returns:
+            Markdown answer followed by a numbered ``## Sources`` section.
+        """
+        output = raw.get("output", {})
+        parts: List[str] = [output.get("content", "")]
+        sources = output.get("sources", [])
+        if sources:
+            lines = ["", "## Sources", ""]
+            for i, src in enumerate(sources, 1):
+                title = src.get("title") or src.get("url", "")
+                url = src.get("url", "")
+                lines.append(f"{i}. [{title}]({url})")
+            parts.append("\n".join(lines))
+        return "\n".join(parts)
+
+    @staticmethod
+    def _parse_contents_results(raw_results: List[Dict]) -> List[Document]:
+        """Convert Contents API response into Documents.
+
+        Uses markdown content as page_content when available, falls back to html.
+        """
+        docs = []
+        for page in raw_results:
+            content = page.get("markdown") or page.get("html") or ""
+            metadata: Dict[str, Any] = {
+                "url": page.get("url"),
+                "title": page.get("title"),
+            }
+            page_metadata = page.get("metadata")
+            if page_metadata:
+                metadata["site_name"] = page_metadata.get("site_name")
+                metadata["favicon_url"] = page_metadata.get("favicon_url")
+            docs.append(Document(page_content=content, metadata=metadata))
+        return docs

--- a/libs/community/tests/integration_tests/retrievers/test_you.py
+++ b/libs/community/tests/integration_tests/retrievers/test_you.py
@@ -1,16 +1,123 @@
 import os
 
+import pytest
+from langchain_core.documents import Document
+
 from langchain_community.retrievers.you import YouRetriever
+from langchain_community.utilities.you import YouSearchAPIWrapper
+
+EXPECTED_METADATA_KEYS = {
+    "url",
+    "title",
+    "description",
+    "thumbnail_url",
+    "favicon_url",
+    "page_age",
+}
+
+
+@pytest.fixture(autouse=True)
+def _require_api_key() -> None:
+    if not os.getenv("YDC_API_KEY"):
+        pytest.skip("YDC_API_KEY not set")
+
+
+class TestYouSearchAPIWrapper:
+    def test_raw_results_structure(self) -> None:
+        wrapper = YouSearchAPIWrapper(count=3)
+        raw = wrapper.raw_results("test query")
+
+        assert "results" in raw
+        assert "web" in raw["results"]
+        assert isinstance(raw["results"]["web"], list)
+        assert len(raw["results"]["web"]) > 0
+
+        hit = raw["results"]["web"][0]
+        assert "url" in hit
+        assert "title" in hit
+        assert "snippets" in hit
+        assert isinstance(hit["snippets"], list)
+
+    def test_results_parsed_metadata(self) -> None:
+        wrapper = YouSearchAPIWrapper(count=3)
+        docs = wrapper.results("python programming")
+
+        assert len(docs) > 0
+        assert all(isinstance(d, Document) for d in docs)
+
+        doc = docs[0]
+        assert isinstance(doc.page_content, str)
+        assert len(doc.page_content) > 0
+        assert doc.metadata.keys() == EXPECTED_METADATA_KEYS
+        assert doc.metadata["url"].startswith("http")
+
+    def test_livecrawl_uses_full_content(self) -> None:
+        wrapper = YouSearchAPIWrapper(
+            count=2, livecrawl="web", livecrawl_formats="markdown"
+        )
+        docs = wrapper.results("what is python")
+
+        assert len(docs) > 0
+        assert docs[0].page_content
+        assert len(docs[0].page_content) > 500
+        assert docs[0].metadata.keys() == EXPECTED_METADATA_KEYS
+
+    def test_contents_parsed_metadata(self) -> None:
+        wrapper = YouSearchAPIWrapper()
+        docs = wrapper.contents(["https://example.com"])
+
+        assert len(docs) == 1
+        assert docs[0].metadata["url"] == "https://example.com"
+        assert len(docs[0].page_content) > 0
+
+    def test_contents_markdown_format(self) -> None:
+        wrapper = YouSearchAPIWrapper()
+        docs = wrapper.contents(["https://example.com"], formats=["markdown"])
+
+        assert len(docs) == 1
+        assert not docs[0].page_content.strip().startswith("<!")
+
+    async def test_results_async(self) -> None:
+        wrapper = YouSearchAPIWrapper(count=3)
+        docs = await wrapper.results_async("test query")
+
+        assert len(docs) > 0
+        assert docs[0].metadata.keys() == EXPECTED_METADATA_KEYS
+
+    async def test_contents_async(self) -> None:
+        wrapper = YouSearchAPIWrapper()
+        docs = await wrapper.contents_async(["https://example.com"])
+
+        assert len(docs) == 1
+        assert docs[0].metadata["url"] == "https://example.com"
 
 
 class TestYouRetriever:
-    @classmethod
-    def setup_class(cls) -> None:
-        if not os.getenv("YDC_API_KEY"):
-            raise ValueError("YDC_API_KEY environment variable is not set")
-
     def test_invoke(self) -> None:
-        retriever = YouRetriever()
-        actual = retriever.invoke("test")
+        retriever = YouRetriever(count=3)
+        docs = retriever.invoke("test query")
 
-        assert len(actual) > 0
+        assert len(docs) > 0
+        assert isinstance(docs[0], Document)
+        assert docs[0].metadata.keys() == EXPECTED_METADATA_KEYS
+
+    async def test_ainvoke(self) -> None:
+        retriever = YouRetriever(count=3)
+        docs = await retriever.ainvoke("test query")
+
+        assert len(docs) > 0
+        assert docs[0].metadata.keys() == EXPECTED_METADATA_KEYS
+
+    def test_invoke_with_livecrawl(self) -> None:
+        retriever = YouRetriever(count=2, livecrawl="web", livecrawl_formats="markdown")
+        docs = retriever.invoke("python tutorial")
+
+        assert len(docs) > 0
+        assert len(docs[0].page_content) > 500
+
+    async def test_ainvoke_with_livecrawl(self) -> None:
+        retriever = YouRetriever(count=2, livecrawl="web", livecrawl_formats="markdown")
+        docs = await retriever.ainvoke("python tutorial")
+
+        assert len(docs) > 0
+        assert len(docs[0].page_content) > 500

--- a/libs/community/tests/integration_tests/tools/test_you.py
+++ b/libs/community/tests/integration_tests/tools/test_you.py
@@ -1,0 +1,20 @@
+import os
+
+from langchain_community.tools.you import YouResearchTool
+from langchain_community.utilities.you import YouSearchAPIWrapper
+
+
+class TestYouResearchTool:
+    @classmethod
+    def setup_class(cls) -> None:
+        if not os.getenv("YDC_API_KEY"):
+            raise ValueError("YDC_API_KEY environment variable is not set")
+
+    def test_invoke(self) -> None:
+        tool = YouResearchTool(api_wrapper=YouSearchAPIWrapper())
+        result = tool.invoke("what is quantum computing")
+
+        assert isinstance(result, str)
+        assert len(result) > 0
+        # response should be markdown with a sources section
+        assert "## Sources" in result

--- a/libs/community/tests/unit_tests/retrievers/test_you.py
+++ b/libs/community/tests/unit_tests/retrievers/test_you.py
@@ -1,3 +1,4 @@
+import warnings
 from unittest.mock import AsyncMock, patch
 
 import responses
@@ -18,18 +19,23 @@ class TestYouRetriever:
     @responses.activate
     def test_invoke(self) -> None:
         responses.add(
-            responses.GET, f"{TEST_ENDPOINT}/search", json=MOCK_RESPONSE_RAW, status=200
+            responses.GET,
+            f"{TEST_ENDPOINT}/v1/search",
+            json=MOCK_RESPONSE_RAW,
+            status=200,
         )
         query = "Test query text"
         you_wrapper = YouRetriever(ydc_api_key="test")
         results = you_wrapper.invoke(query)
-        expected_result = MOCK_PARSED_OUTPUT
-        assert results == expected_result
+        assert results == MOCK_PARSED_OUTPUT
 
     @responses.activate
     def test_invoke_max_docs(self) -> None:
         responses.add(
-            responses.GET, f"{TEST_ENDPOINT}/search", json=MOCK_RESPONSE_RAW, status=200
+            responses.GET,
+            f"{TEST_ENDPOINT}/v1/search",
+            json=MOCK_RESPONSE_RAW,
+            status=200,
         )
         query = "Test query text"
         you_wrapper = YouRetriever(k=2, ydc_api_key="test")
@@ -40,41 +46,41 @@ class TestYouRetriever:
     @responses.activate
     def test_invoke_limit_snippets(self) -> None:
         responses.add(
-            responses.GET, f"{TEST_ENDPOINT}/search", json=MOCK_RESPONSE_RAW, status=200
+            responses.GET,
+            f"{TEST_ENDPOINT}/v1/search",
+            json=MOCK_RESPONSE_RAW,
+            status=200,
         )
-
         query = "Test query text"
         you_wrapper = YouRetriever(n_snippets_per_hit=1, ydc_api_key="test")
         results = you_wrapper.results(query)
-        expected_result = LIMITED_PARSED_OUTPUT
-        assert results == expected_result
+        assert results == LIMITED_PARSED_OUTPUT
 
     @responses.activate
     def test_invoke_news(self) -> None:
         responses.add(
-            responses.GET, f"{TEST_ENDPOINT}/news", json=NEWS_RESPONSE_RAW, status=200
+            responses.GET,
+            f"{TEST_ENDPOINT}/v1/search",
+            json=NEWS_RESPONSE_RAW,
+            status=200,
         )
-
         query = "Test news text"
-        # ensure limit on number of docs returned
-        you_wrapper = YouRetriever(endpoint_type="news", ydc_api_key="test")
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            you_wrapper = YouRetriever(endpoint_type="news", ydc_api_key="test")
         results = you_wrapper.results(query)
-        expected_result = NEWS_RESPONSE_PARSED
-        assert results == expected_result
+        assert results == NEWS_RESPONSE_PARSED
 
     async def test_ainvoke(self) -> None:
         instance = YouRetriever(ydc_api_key="test_api_key")
 
-        # Mock response object to simulate aiohttp response
         mock_response = AsyncMock()
-        mock_response.__aenter__.return_value = (
-            mock_response  # Make the context manager return itself
-        )
-        mock_response.__aexit__.return_value = None  # No value needed for exit
+        mock_response.__aenter__.return_value = mock_response
+        mock_response.__aexit__.return_value = None
         mock_response.status = 200
         mock_response.json = AsyncMock(return_value=MOCK_RESPONSE_RAW)
+        mock_response.raise_for_status = lambda: None
 
-        # Patch the aiohttp.ClientSession object
         with patch("aiohttp.ClientSession.get", return_value=mock_response):
             results = await instance.ainvoke("test query")
             assert results == MOCK_PARSED_OUTPUT

--- a/libs/community/tests/unit_tests/tools/test_imports.py
+++ b/libs/community/tests/unit_tests/tools/test_imports.py
@@ -136,6 +136,7 @@ EXPECTED_ALL = [
     "WolframAlphaQueryRun",
     "WriteFileTool",
     "YahooFinanceNewsTool",
+    "YouContentsTool",
     "YouSearchTool",
     "YouTubeSearchTool",
     "ZapierNLAListActions",

--- a/libs/community/tests/unit_tests/tools/test_you.py
+++ b/libs/community/tests/unit_tests/tools/test_you.py
@@ -1,17 +1,23 @@
+import warnings
 from unittest.mock import AsyncMock, patch
 
 import responses
 
-from langchain_community.tools.you import YouSearchTool
+from langchain_community.tools.you import YouContentsTool, YouResearchTool, YouSearchTool
 from langchain_community.utilities.you import YouSearchAPIWrapper
 
 from ..utilities.test_you import (
     LIMITED_PARSED_OUTPUT,
+    MOCK_CONTENTS_PARSED,
+    MOCK_CONTENTS_RESPONSE,
     MOCK_PARSED_OUTPUT,
+    MOCK_RESEARCH_RESPONSE,
+    MOCK_RESEARCH_TEXT,
     MOCK_RESPONSE_RAW,
     NEWS_RESPONSE_PARSED,
     NEWS_RESPONSE_RAW,
     TEST_ENDPOINT,
+    TEST_RESEARCH_ENDPOINT,
 )
 
 
@@ -19,18 +25,23 @@ class TestYouSearchTool:
     @responses.activate
     def test_invoke(self) -> None:
         responses.add(
-            responses.GET, f"{TEST_ENDPOINT}/search", json=MOCK_RESPONSE_RAW, status=200
+            responses.GET,
+            f"{TEST_ENDPOINT}/v1/search",
+            json=MOCK_RESPONSE_RAW,
+            status=200,
         )
         query = "Test query text"
         you_tool = YouSearchTool(api_wrapper=YouSearchAPIWrapper(ydc_api_key="test"))
         results = you_tool.invoke(query)
-        expected_result = MOCK_PARSED_OUTPUT
-        assert results == expected_result
+        assert results == MOCK_PARSED_OUTPUT
 
     @responses.activate
     def test_invoke_max_docs(self) -> None:
         responses.add(
-            responses.GET, f"{TEST_ENDPOINT}/search", json=MOCK_RESPONSE_RAW, status=200
+            responses.GET,
+            f"{TEST_ENDPOINT}/v1/search",
+            json=MOCK_RESPONSE_RAW,
+            status=200,
         )
         query = "Test query text"
         you_tool = YouSearchTool(
@@ -43,43 +54,116 @@ class TestYouSearchTool:
     @responses.activate
     def test_invoke_limit_snippets(self) -> None:
         responses.add(
-            responses.GET, f"{TEST_ENDPOINT}/search", json=MOCK_RESPONSE_RAW, status=200
+            responses.GET,
+            f"{TEST_ENDPOINT}/v1/search",
+            json=MOCK_RESPONSE_RAW,
+            status=200,
         )
         query = "Test query text"
         you_tool = YouSearchTool(
             api_wrapper=YouSearchAPIWrapper(ydc_api_key="test", n_snippets_per_hit=1)
         )
         results = you_tool.invoke(query)
-        expected_result = LIMITED_PARSED_OUTPUT
-        assert results == expected_result
+        assert results == LIMITED_PARSED_OUTPUT
 
     @responses.activate
     def test_invoke_news(self) -> None:
         responses.add(
-            responses.GET, f"{TEST_ENDPOINT}/news", json=NEWS_RESPONSE_RAW, status=200
+            responses.GET,
+            f"{TEST_ENDPOINT}/v1/search",
+            json=NEWS_RESPONSE_RAW,
+            status=200,
         )
-
-        query = "Test news text"
-        you_tool = YouSearchTool(
-            api_wrapper=YouSearchAPIWrapper(ydc_api_key="test", endpoint_type="news")
-        )
-        results = you_tool.invoke(query)
-        expected_result = NEWS_RESPONSE_PARSED
-        assert results == expected_result
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", DeprecationWarning)
+            you_tool = YouSearchTool(
+                api_wrapper=YouSearchAPIWrapper(
+                    ydc_api_key="test", endpoint_type="news"
+                )
+            )
+        results = you_tool.invoke("Test news text")
+        assert results == NEWS_RESPONSE_PARSED
 
     async def test_ainvoke(self) -> None:
         you_tool = YouSearchTool(api_wrapper=YouSearchAPIWrapper(ydc_api_key="test"))
 
-        # Mock response object to simulate aiohttp response
         mock_response = AsyncMock()
-        mock_response.__aenter__.return_value = (
-            mock_response  # Make the context manager return itself
-        )
-        mock_response.__aexit__.return_value = None  # No value needed for exit
+        mock_response.__aenter__.return_value = mock_response
+        mock_response.__aexit__.return_value = None
         mock_response.status = 200
         mock_response.json = AsyncMock(return_value=MOCK_RESPONSE_RAW)
+        mock_response.raise_for_status = lambda: None
 
-        # Patch the aiohttp.ClientSession object
         with patch("aiohttp.ClientSession.get", return_value=mock_response):
             results = await you_tool.ainvoke("test query")
             assert results == MOCK_PARSED_OUTPUT
+
+
+class TestYouContentsTool:
+    @responses.activate
+    def test_invoke(self) -> None:
+        responses.add(
+            responses.POST,
+            f"{TEST_ENDPOINT}/v1/contents",
+            json=MOCK_CONTENTS_RESPONSE,
+            status=200,
+        )
+        you_tool = YouContentsTool(api_wrapper=YouSearchAPIWrapper(ydc_api_key="test"))
+        results = you_tool.invoke({"urls": ["https://example.com"]})
+        assert results == MOCK_CONTENTS_PARSED
+
+    async def test_ainvoke(self) -> None:
+        you_tool = YouContentsTool(api_wrapper=YouSearchAPIWrapper(ydc_api_key="test"))
+
+        mock_response = AsyncMock()
+        mock_response.__aenter__.return_value = mock_response
+        mock_response.__aexit__.return_value = None
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=MOCK_CONTENTS_RESPONSE)
+        mock_response.raise_for_status = lambda: None
+
+        with patch("aiohttp.ClientSession.post", return_value=mock_response):
+            results = await you_tool.ainvoke({"urls": ["https://example.com"]})
+            assert results == MOCK_CONTENTS_PARSED
+
+
+class TestYouResearchTool:
+    @responses.activate
+    def test_invoke(self) -> None:
+        responses.add(
+            responses.POST,
+            f"{TEST_RESEARCH_ENDPOINT}/v1/research",
+            json=MOCK_RESEARCH_RESPONSE,
+            status=200,
+        )
+        you_tool = YouResearchTool(api_wrapper=YouSearchAPIWrapper(ydc_api_key="test"))
+        result = you_tool.invoke("quantum computing advances")
+        assert result == MOCK_RESEARCH_TEXT
+
+    @responses.activate
+    def test_invoke_with_effort(self) -> None:
+        responses.add(
+            responses.POST,
+            f"{TEST_RESEARCH_ENDPOINT}/v1/research",
+            json=MOCK_RESEARCH_RESPONSE,
+            status=200,
+        )
+        you_tool = YouResearchTool(
+            api_wrapper=YouSearchAPIWrapper(ydc_api_key="test", research_effort="deep")
+        )
+        result = you_tool.invoke("quantum computing advances")
+        assert result == MOCK_RESEARCH_TEXT
+
+    async def test_ainvoke(self) -> None:
+        you_tool = YouResearchTool(api_wrapper=YouSearchAPIWrapper(ydc_api_key="test"))
+
+        mock_response = AsyncMock()
+        mock_response.__aenter__.return_value = mock_response
+        mock_response.__aexit__.return_value = None
+        mock_response.status = 200
+        mock_response.json = AsyncMock(return_value=MOCK_RESEARCH_RESPONSE)
+        mock_response.raise_for_status = lambda: None
+
+        with patch("aiohttp.ClientSession.post", return_value=mock_response):
+            result = await you_tool.ainvoke("quantum computing advances")
+            assert result == MOCK_RESEARCH_TEXT

--- a/libs/community/tests/unit_tests/utilities/test_you.py
+++ b/libs/community/tests/unit_tests/utilities/test_you.py
@@ -1,4 +1,6 @@
-from typing import Any, Dict, List, Optional, Union
+import json
+import warnings
+from typing import Any, Dict, List, Optional
 from unittest.mock import AsyncMock, patch
 
 import responses
@@ -6,50 +8,60 @@ from langchain_core.documents import Document
 
 from langchain_community.utilities.you import YouSearchAPIWrapper
 
-TEST_ENDPOINT = "https://api.ydc-index.io"
+TEST_ENDPOINT = "https://ydc-index.io"
+TEST_RESEARCH_ENDPOINT = "https://api.you.com"
 
-# Mock you.com response for testing
-MOCK_RESPONSE_RAW: Dict[str, List[Dict[str, Union[str, List[str]]]]] = {
-    "hits": [
-        {
-            "description": "Test description",
-            "snippets": ["yo", "bird up"],
-            "thumbnail_url": "https://example.com/image.gif",
-            "title": "Test title 1",
-            "url": "https://example.com/article.html",
-        },
-        {
-            "description": "Test description 2",
-            "snippets": ["worst show", "on tv"],
-            "thumbnail_url": "https://example.com/image2.gif",
-            "title": "Test title 2",
-            "url": "https://example.com/article2.html",
-        },
-    ]
+# Mock v1/search response
+MOCK_RESPONSE_RAW: Dict[str, Any] = {
+    "results": {
+        "web": [
+            {
+                "description": "Test description",
+                "snippets": ["yo", "bird up"],
+                "thumbnail_url": "https://example.com/image.gif",
+                "title": "Test title 1",
+                "url": "https://example.com/article.html",
+                "favicon_url": "https://example.com/favicon.ico",
+                "page_age": "2024-01-15T00:00:00Z",
+            },
+            {
+                "description": "Test description 2",
+                "snippets": ["worst show", "on tv"],
+                "thumbnail_url": "https://example.com/image2.gif",
+                "title": "Test title 2",
+                "url": "https://example.com/article2.html",
+                "favicon_url": "https://example.com/favicon2.ico",
+                "page_age": "2024-01-16T00:00:00Z",
+            },
+        ],
+        "news": [],
+    }
 }
 
 
-def generate_parsed_metadata(num: Optional[int] = 0) -> Dict[Any, Any]:
-    """generate metadata for testing"""
+def generate_parsed_metadata(num: Optional[int] = 0) -> Dict[str, Any]:
+    """Generate metadata for testing."""
     if num is None:
         num = 0
-    hit: Dict[str, Union[str, List[str]]] = MOCK_RESPONSE_RAW["hits"][num]
+    hit = MOCK_RESPONSE_RAW["results"]["web"][num]
     return {
         "url": hit["url"],
         "thumbnail_url": hit["thumbnail_url"],
         "title": hit["title"],
         "description": hit["description"],
+        "favicon_url": hit["favicon_url"],
+        "page_age": hit["page_age"],
     }
 
 
 def generate_parsed_output(num: Optional[int] = 0) -> List[Document]:
-    """generate parsed output for testing"""
+    """Generate parsed output for testing."""
     if num is None:
         num = 0
-    hit: Dict[str, Union[str, List[str]]] = MOCK_RESPONSE_RAW["hits"][num]
+    hit = MOCK_RESPONSE_RAW["results"]["web"][num]
     output = []
-    for snippit in hit["snippets"]:
-        doc = Document(page_content=snippit, metadata=generate_parsed_metadata(num))
+    for snippet in hit["snippets"]:
+        doc = Document(page_content=snippet, metadata=generate_parsed_metadata(num))
         output.append(doc)
     return output
 
@@ -57,103 +69,204 @@ def generate_parsed_output(num: Optional[int] = 0) -> List[Document]:
 # Mock results after parsing
 MOCK_PARSED_OUTPUT = generate_parsed_output()
 MOCK_PARSED_OUTPUT.extend(generate_parsed_output(1))
-# Single-snippet
+# Single-snippet per hit
 LIMITED_PARSED_OUTPUT = []
 LIMITED_PARSED_OUTPUT.append(generate_parsed_output()[0])
 LIMITED_PARSED_OUTPUT.append(generate_parsed_output(1)[0])
 
-# copied from you api docs
-NEWS_RESPONSE_RAW = {
-    "news": {
-        "results": [
+NEWS_RESPONSE_RAW: Dict[str, Any] = {
+    "results": {
+        "web": [],
+        "news": [
             {
-                "age": "18 hours ago",
-                "breaking": True,
-                "description": "Search on YDC for the news",
-                "meta_url": {
-                    "hostname": "www.reuters.com",
-                    "netloc": "reuters.com",
-                    "path": "› 2023  › 10  › 18  › politics  › inflation  › index.html",
-                    "scheme": "https",
-                },
-                "page_age": "2 days",
-                "page_fetched": "2023-10-12T23:00:00Z",
-                "thumbnail": {"original": "https://reuters.com/news.jpg"},
                 "title": "Breaking News about the World's Greatest Search Engine!",
-                "type": "news",
+                "description": "Search on YDC for the news",
+                "page_age": "2023-10-12T23:00:00Z",
+                "thumbnail_url": "https://reuters.com/news.jpg",
                 "url": "https://news.you.com",
             }
-        ]
+        ],
     }
 }
 
 NEWS_RESPONSE_PARSED = [
     Document(page_content=str(result["description"]), metadata=result)
-    for result in NEWS_RESPONSE_RAW["news"]["results"]
+    for result in NEWS_RESPONSE_RAW["results"]["news"]
 ]
+
+NEWS_LIVECRAWL_RESPONSE_RAW: Dict[str, Any] = {
+    "results": {
+        "web": [],
+        "news": [
+            {
+                "title": "Breaking News!",
+                "description": "Short description",
+                "page_age": "2024-01-01T00:00:00Z",
+                "thumbnail_url": "https://example.com/news.jpg",
+                "url": "https://news.example.com",
+                "contents": {
+                    "markdown": "# Full News Article\n\nDetailed content here.",
+                },
+            }
+        ],
+    }
+}
+
+LIVECRAWL_RESPONSE_RAW: Dict[str, Any] = {
+    "results": {
+        "web": [
+            {
+                "description": "Test description",
+                "snippets": ["short snippet"],
+                "thumbnail_url": "https://example.com/image.gif",
+                "title": "Livecrawled Page",
+                "url": "https://example.com/page.html",
+                "favicon_url": "https://example.com/favicon.ico",
+                "page_age": "2024-06-01T00:00:00Z",
+                "contents": {
+                    "markdown": "# Full Page Content\n\n"
+                    "This is the livecrawled markdown.",
+                },
+            },
+            {
+                "description": "No livecrawl hit",
+                "snippets": ["fallback snippet 1", "fallback snippet 2"],
+                "thumbnail_url": None,
+                "title": "Regular Page",
+                "url": "https://example.com/regular.html",
+                "favicon_url": "https://example.com/favicon2.ico",
+                "page_age": None,
+            },
+        ],
+        "news": [],
+    }
+}
+
+LIVECRAWL_HTML_RESPONSE_RAW: Dict[str, Any] = {
+    "results": {
+        "web": [
+            {
+                "description": "HTML only",
+                "snippets": ["snippet"],
+                "thumbnail_url": None,
+                "title": "HTML Page",
+                "url": "https://example.com/html.html",
+                "favicon_url": None,
+                "page_age": None,
+                "contents": {
+                    "html": "<h1>Full HTML</h1><p>Content here.</p>",
+                },
+            },
+        ],
+        "news": [],
+    }
+}
+
+MOCK_CONTENTS_RESPONSE: List[Dict[str, Any]] = [
+    {
+        "url": "https://example.com",
+        "title": "Example Page",
+        "html": "<h1>Hello</h1>",
+        "markdown": "# Hello",
+        "metadata": {
+            "site_name": "Example",
+            "favicon_url": "https://example.com/favicon.ico",
+        },
+    }
+]
+
+MOCK_CONTENTS_PARSED = [
+    Document(
+        page_content="# Hello",
+        metadata={
+            "url": "https://example.com",
+            "title": "Example Page",
+            "site_name": "Example",
+            "favicon_url": "https://example.com/favicon.ico",
+        },
+    )
+]
+
+MOCK_RESEARCH_RESPONSE: Dict[str, Any] = {
+    "output": {
+        "content": "Quantum computing has seen major advances recently.[1]",
+        "content_type": "text",
+        "sources": [
+            {
+                "url": "https://nature.com/quantum",
+                "title": "Nature Quantum",
+                "snippets": ["Major breakthroughs in qubit stability."],
+            },
+            {
+                "url": "https://arxiv.org/quantum",
+                "snippets": ["Error correction improvements."],
+            },
+        ],
+    }
+}
+
+MOCK_RESEARCH_TEXT = (
+    "Quantum computing has seen major advances recently.[1]"
+    "\n\n## Sources\n\n"
+    "1. [Nature Quantum](https://nature.com/quantum)\n"
+    "2. [https://arxiv.org/quantum](https://arxiv.org/quantum)"
+)
 
 
 @responses.activate
 def test_raw_results() -> None:
     responses.add(
-        responses.GET, f"{TEST_ENDPOINT}/search", json=MOCK_RESPONSE_RAW, status=200
+        responses.GET,
+        f"{TEST_ENDPOINT}/v1/search",
+        json=MOCK_RESPONSE_RAW,
+        status=200,
     )
-
     query = "Test query text"
-    # ensure default endpoint_type
-    you_wrapper = YouSearchAPIWrapper(endpoint_type="snippet", ydc_api_key="test")
-    raw_results = you_wrapper.raw_results(query)
-    expected_result = MOCK_RESPONSE_RAW
-    assert raw_results == expected_result
-
-
-@responses.activate
-def test_raw_results_defaults() -> None:
-    responses.add(
-        responses.GET, f"{TEST_ENDPOINT}/search", json=MOCK_RESPONSE_RAW, status=200
-    )
-
-    query = "Test query text"
-    # ensure limit on number of docs returned
     you_wrapper = YouSearchAPIWrapper(ydc_api_key="test")
     raw_results = you_wrapper.raw_results(query)
-    expected_result = MOCK_RESPONSE_RAW
-    assert raw_results == expected_result
+    assert raw_results == MOCK_RESPONSE_RAW
 
 
 @responses.activate
-def test_raw_results_news() -> None:
+def test_raw_results_with_snippet_endpoint() -> None:
     responses.add(
-        responses.GET, f"{TEST_ENDPOINT}/news", json=NEWS_RESPONSE_RAW, status=200
+        responses.GET,
+        f"{TEST_ENDPOINT}/v1/search",
+        json=MOCK_RESPONSE_RAW,
+        status=200,
     )
-
-    query = "Test news text"
-    # ensure limit on number of docs returned
-    you_wrapper = YouSearchAPIWrapper(endpoint_type="news", ydc_api_key="test")
+    query = "Test query text"
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        you_wrapper = YouSearchAPIWrapper(endpoint_type="snippet", ydc_api_key="test")
     raw_results = you_wrapper.raw_results(query)
-    expected_result = NEWS_RESPONSE_RAW
-    assert raw_results == expected_result
+    assert raw_results == MOCK_RESPONSE_RAW
+    # Verify endpoint_type was NOT mutated
+    assert you_wrapper.endpoint_type == "snippet"
 
 
 @responses.activate
 def test_results() -> None:
     responses.add(
-        responses.GET, f"{TEST_ENDPOINT}/search", json=MOCK_RESPONSE_RAW, status=200
+        responses.GET,
+        f"{TEST_ENDPOINT}/v1/search",
+        json=MOCK_RESPONSE_RAW,
+        status=200,
     )
-
     query = "Test query text"
     you_wrapper = YouSearchAPIWrapper(ydc_api_key="test")
     results = you_wrapper.results(query)
-    expected_result = MOCK_PARSED_OUTPUT
-    assert results == expected_result
+    assert results == MOCK_PARSED_OUTPUT
 
 
 @responses.activate
 def test_results_max_docs() -> None:
     responses.add(
-        responses.GET, f"{TEST_ENDPOINT}/search", json=MOCK_RESPONSE_RAW, status=200
+        responses.GET,
+        f"{TEST_ENDPOINT}/v1/search",
+        json=MOCK_RESPONSE_RAW,
+        status=200,
     )
-
     query = "Test query text"
     you_wrapper = YouSearchAPIWrapper(k=2, ydc_api_key="test")
     results = you_wrapper.results(query)
@@ -164,43 +277,192 @@ def test_results_max_docs() -> None:
 @responses.activate
 def test_results_limit_snippets() -> None:
     responses.add(
-        responses.GET, f"{TEST_ENDPOINT}/search", json=MOCK_RESPONSE_RAW, status=200
+        responses.GET,
+        f"{TEST_ENDPOINT}/v1/search",
+        json=MOCK_RESPONSE_RAW,
+        status=200,
     )
-
     query = "Test query text"
     you_wrapper = YouSearchAPIWrapper(n_snippets_per_hit=1, ydc_api_key="test")
     results = you_wrapper.results(query)
-    expected_result = LIMITED_PARSED_OUTPUT
-    assert results == expected_result
+    assert results == LIMITED_PARSED_OUTPUT
 
 
 @responses.activate
 def test_results_news() -> None:
     responses.add(
-        responses.GET, f"{TEST_ENDPOINT}/news", json=NEWS_RESPONSE_RAW, status=200
+        responses.GET,
+        f"{TEST_ENDPOINT}/v1/search",
+        json=NEWS_RESPONSE_RAW,
+        status=200,
     )
-
     query = "Test news text"
-    # ensure limit on number of docs returned
-    you_wrapper = YouSearchAPIWrapper(endpoint_type="news", ydc_api_key="test")
-    raw_results = you_wrapper.results(query)
-    expected_result = NEWS_RESPONSE_PARSED
-    assert raw_results == expected_result
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        you_wrapper = YouSearchAPIWrapper(endpoint_type="news", ydc_api_key="test")
+    results = you_wrapper.results(query)
+    assert results == NEWS_RESPONSE_PARSED
+
+
+@responses.activate
+def test_contents() -> None:
+    responses.add(
+        responses.POST,
+        f"{TEST_ENDPOINT}/v1/contents",
+        json=MOCK_CONTENTS_RESPONSE,
+        status=200,
+    )
+    you_wrapper = YouSearchAPIWrapper(ydc_api_key="test")
+    results = you_wrapper.contents(["https://example.com"])
+    assert results == MOCK_CONTENTS_PARSED
+
+
+@responses.activate
+def test_search_params_passed_through() -> None:
+    responses.add(
+        responses.GET,
+        f"{TEST_ENDPOINT}/v1/search",
+        json=MOCK_RESPONSE_RAW,
+        status=200,
+    )
+    you_wrapper = YouSearchAPIWrapper(
+        ydc_api_key="test",
+        count=5,
+        freshness="week",
+        offset=1,
+        livecrawl="web",
+        livecrawl_formats="markdown",
+        country="US",
+        safesearch="strict",
+        language="fr",
+    )
+    you_wrapper.raw_results("test")
+    request = responses.calls[0].request
+    assert request.url is not None
+    assert "count=5" in request.url
+    assert "freshness=week" in request.url
+    assert "offset=1" in request.url
+    assert "livecrawl=web" in request.url
+    assert "livecrawl_formats=markdown" in request.url
+    assert "country=US" in request.url
+    assert "safesearch=strict" in request.url
+    assert "language=fr" in request.url
+
+
+@responses.activate
+def test_num_web_results_maps_to_count() -> None:
+    responses.add(
+        responses.GET,
+        f"{TEST_ENDPOINT}/v1/search",
+        json=MOCK_RESPONSE_RAW,
+        status=200,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        you_wrapper = YouSearchAPIWrapper(ydc_api_key="test", num_web_results=5)
+    you_wrapper.raw_results("test")
+    request = responses.calls[0].request
+    assert request.url is not None
+    assert "count=5" in request.url
+
+
+def test_deprecated_num_web_results_warning() -> None:
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        YouSearchAPIWrapper(ydc_api_key="test", num_web_results=5)
+        deprecation_warnings = [
+            x for x in w if issubclass(x.category, DeprecationWarning)
+        ]
+        assert any("num_web_results" in str(x.message) for x in deprecation_warnings)
+
+
+def test_deprecated_news_endpoint_warning() -> None:
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        YouSearchAPIWrapper(ydc_api_key="test", endpoint_type="news")
+        deprecation_warnings = [
+            x for x in w if issubclass(x.category, DeprecationWarning)
+        ]
+        assert any("news" in str(x.message) for x in deprecation_warnings)
+
+
+def test_deprecated_snippet_endpoint_warning() -> None:
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        YouSearchAPIWrapper(ydc_api_key="test", endpoint_type="snippet")
+        deprecation_warnings = [
+            x for x in w if issubclass(x.category, DeprecationWarning)
+        ]
+        assert any("snippet" in str(x.message) for x in deprecation_warnings)
+
+
+def test_deprecated_rag_endpoint_warning() -> None:
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        YouSearchAPIWrapper(ydc_api_key="test", endpoint_type="rag")
+        deprecation_warnings = [
+            x for x in w if issubclass(x.category, DeprecationWarning)
+        ]
+        assert any("rag" in str(x.message) for x in deprecation_warnings)
+
+
+def test_deprecated_n_hits_warning() -> None:
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        YouSearchAPIWrapper(ydc_api_key="test", n_hits=5)
+        deprecation_warnings = [
+            x for x in w if issubclass(x.category, DeprecationWarning)
+        ]
+        assert any("n_hits" in str(x.message) for x in deprecation_warnings)
+
+
+def test_deprecated_search_lang_warning() -> None:
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        YouSearchAPIWrapper(ydc_api_key="test", search_lang="en")
+        deprecation_warnings = [
+            x for x in w if issubclass(x.category, DeprecationWarning)
+        ]
+        assert any("search_lang" in str(x.message) for x in deprecation_warnings)
+
+
+def test_deprecated_ui_lang_warning() -> None:
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        YouSearchAPIWrapper(ydc_api_key="test", ui_lang="en")
+        deprecation_warnings = [
+            x for x in w if issubclass(x.category, DeprecationWarning)
+        ]
+        assert any("ui_lang" in str(x.message) for x in deprecation_warnings)
+
+
+def test_deprecated_spellcheck_warning() -> None:
+    with warnings.catch_warnings(record=True) as w:
+        warnings.simplefilter("always")
+        YouSearchAPIWrapper(ydc_api_key="test", spellcheck=True)
+        deprecation_warnings = [
+            x for x in w if issubclass(x.category, DeprecationWarning)
+        ]
+        assert any("spellcheck" in str(x.message) for x in deprecation_warnings)
+
+
+def test_snippet_endpoint_does_not_mutate_state() -> None:
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        wrapper = YouSearchAPIWrapper(endpoint_type="snippet", ydc_api_key="test")
+    assert wrapper.endpoint_type == "snippet"
 
 
 async def test_raw_results_async() -> None:
     instance = YouSearchAPIWrapper(ydc_api_key="test_api_key")
 
-    # Mock response object to simulate aiohttp response
     mock_response = AsyncMock()
-    mock_response.__aenter__.return_value = (
-        mock_response  # Make the context manager return itself
-    )
-    mock_response.__aexit__.return_value = None  # No value needed for exit
+    mock_response.__aenter__.return_value = mock_response
+    mock_response.__aexit__.return_value = None
     mock_response.status = 200
     mock_response.json = AsyncMock(return_value=MOCK_RESPONSE_RAW)
+    mock_response.raise_for_status = lambda: None
 
-    # Patch the aiohttp.ClientSession object
     with patch("aiohttp.ClientSession.get", return_value=mock_response):
         results = await instance.raw_results_async("test query")
         assert results == MOCK_RESPONSE_RAW
@@ -209,34 +471,254 @@ async def test_raw_results_async() -> None:
 async def test_results_async() -> None:
     instance = YouSearchAPIWrapper(ydc_api_key="test_api_key")
 
-    # Mock response object to simulate aiohttp response
     mock_response = AsyncMock()
-    mock_response.__aenter__.return_value = (
-        mock_response  # Make the context manager return itself
-    )
-    mock_response.__aexit__.return_value = None  # No value needed for exit
+    mock_response.__aenter__.return_value = mock_response
+    mock_response.__aexit__.return_value = None
     mock_response.status = 200
     mock_response.json = AsyncMock(return_value=MOCK_RESPONSE_RAW)
+    mock_response.raise_for_status = lambda: None
 
-    # Patch the aiohttp.ClientSession object
     with patch("aiohttp.ClientSession.get", return_value=mock_response):
         results = await instance.results_async("test query")
         assert results == MOCK_PARSED_OUTPUT
 
 
 async def test_results_news_async() -> None:
-    instance = YouSearchAPIWrapper(endpoint_type="news", ydc_api_key="test_api_key")
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        instance = YouSearchAPIWrapper(endpoint_type="news", ydc_api_key="test_api_key")
 
-    # Mock response object to simulate aiohttp response
     mock_response = AsyncMock()
-    mock_response.__aenter__.return_value = (
-        mock_response  # Make the context manager return itself
-    )
-    mock_response.__aexit__.return_value = None  # No value needed for exit
+    mock_response.__aenter__.return_value = mock_response
+    mock_response.__aexit__.return_value = None
     mock_response.status = 200
     mock_response.json = AsyncMock(return_value=NEWS_RESPONSE_RAW)
+    mock_response.raise_for_status = lambda: None
 
-    # Patch the aiohttp.ClientSession object
     with patch("aiohttp.ClientSession.get", return_value=mock_response):
         results = await instance.results_async("test query")
         assert results == NEWS_RESPONSE_PARSED
+
+
+async def test_contents_async() -> None:
+    instance = YouSearchAPIWrapper(ydc_api_key="test_api_key")
+
+    mock_response = AsyncMock()
+    mock_response.__aenter__.return_value = mock_response
+    mock_response.__aexit__.return_value = None
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value=MOCK_CONTENTS_RESPONSE)
+    mock_response.raise_for_status = lambda: None
+
+    with patch("aiohttp.ClientSession.post", return_value=mock_response):
+        results = await instance.contents_async(["https://example.com"])
+        assert results == MOCK_CONTENTS_PARSED
+
+
+@responses.activate
+def test_livecrawl_markdown_preferred_over_snippets() -> None:
+    responses.add(
+        responses.GET,
+        f"{TEST_ENDPOINT}/v1/search",
+        json=LIVECRAWL_RESPONSE_RAW,
+        status=200,
+    )
+    wrapper = YouSearchAPIWrapper(ydc_api_key="test", livecrawl="web")
+    results = wrapper.results("test")
+    assert len(results) == 3
+    assert results[0].page_content == (
+        "# Full Page Content\n\nThis is the livecrawled markdown."
+    )
+    assert results[0].metadata["url"] == "https://example.com/page.html"
+    assert results[1].page_content == "fallback snippet 1"
+    assert results[2].page_content == "fallback snippet 2"
+
+
+@responses.activate
+def test_livecrawl_html_fallback() -> None:
+    responses.add(
+        responses.GET,
+        f"{TEST_ENDPOINT}/v1/search",
+        json=LIVECRAWL_HTML_RESPONSE_RAW,
+        status=200,
+    )
+    wrapper = YouSearchAPIWrapper(ydc_api_key="test", livecrawl="web")
+    results = wrapper.results("test")
+    assert len(results) == 1
+    assert results[0].page_content == "<h1>Full HTML</h1><p>Content here.</p>"
+
+
+@responses.activate
+def test_livecrawl_empty_contents_falls_back_to_snippets() -> None:
+    empty_contents_response: Dict[str, Any] = {
+        "results": {
+            "web": [
+                {
+                    "description": "Has empty contents",
+                    "snippets": ["real snippet"],
+                    "thumbnail_url": None,
+                    "title": "Page",
+                    "url": "https://example.com/page.html",
+                    "favicon_url": None,
+                    "page_age": None,
+                    "contents": {},
+                },
+            ],
+            "news": [],
+        }
+    }
+    responses.add(
+        responses.GET,
+        f"{TEST_ENDPOINT}/v1/search",
+        json=empty_contents_response,
+        status=200,
+    )
+    wrapper = YouSearchAPIWrapper(ydc_api_key="test", livecrawl="web")
+    results = wrapper.results("test")
+    assert len(results) == 1
+    assert results[0].page_content == "real snippet"
+
+
+@responses.activate
+def test_livecrawl_ignores_n_snippets_per_hit() -> None:
+    responses.add(
+        responses.GET,
+        f"{TEST_ENDPOINT}/v1/search",
+        json=LIVECRAWL_RESPONSE_RAW,
+        status=200,
+    )
+    wrapper = YouSearchAPIWrapper(
+        ydc_api_key="test", livecrawl="web", n_snippets_per_hit=1
+    )
+    results = wrapper.results("test")
+    assert results[0].page_content == (
+        "# Full Page Content\n\nThis is the livecrawled markdown."
+    )
+    assert results[1].page_content == "fallback snippet 1"
+    assert len(results) == 2
+
+
+@responses.activate
+def test_livecrawl_k_limits_total_docs() -> None:
+    responses.add(
+        responses.GET,
+        f"{TEST_ENDPOINT}/v1/search",
+        json=LIVECRAWL_RESPONSE_RAW,
+        status=200,
+    )
+    wrapper = YouSearchAPIWrapper(ydc_api_key="test", livecrawl="web", k=1)
+    results = wrapper.results("test")
+    assert len(results) == 1
+    assert results[0].page_content == (
+        "# Full Page Content\n\nThis is the livecrawled markdown."
+    )
+
+
+@responses.activate
+def test_news_livecrawl_prefers_contents_over_description() -> None:
+    responses.add(
+        responses.GET,
+        f"{TEST_ENDPOINT}/v1/search",
+        json=NEWS_LIVECRAWL_RESPONSE_RAW,
+        status=200,
+    )
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", DeprecationWarning)
+        wrapper = YouSearchAPIWrapper(
+            ydc_api_key="test", endpoint_type="news", livecrawl="news"
+        )
+    results = wrapper.results("test")
+    assert len(results) == 1
+    assert results[0].page_content == ("# Full News Article\n\nDetailed content here.")
+
+
+@responses.activate
+def test_raw_research() -> None:
+    responses.add(
+        responses.POST,
+        f"{TEST_RESEARCH_ENDPOINT}/v1/research",
+        json=MOCK_RESEARCH_RESPONSE,
+        status=200,
+    )
+    wrapper = YouSearchAPIWrapper(ydc_api_key="test")
+    result = wrapper.raw_research("quantum computing advances")
+    assert result == MOCK_RESEARCH_RESPONSE
+
+
+@responses.activate
+def test_research_text() -> None:
+    responses.add(
+        responses.POST,
+        f"{TEST_RESEARCH_ENDPOINT}/v1/research",
+        json=MOCK_RESEARCH_RESPONSE,
+        status=200,
+    )
+    wrapper = YouSearchAPIWrapper(ydc_api_key="test")
+    result = wrapper.research_text("quantum computing advances")
+    assert result == MOCK_RESEARCH_TEXT
+
+
+@responses.activate
+def test_research_effort_passed_through() -> None:
+    responses.add(
+        responses.POST,
+        f"{TEST_RESEARCH_ENDPOINT}/v1/research",
+        json=MOCK_RESEARCH_RESPONSE,
+        status=200,
+    )
+    wrapper = YouSearchAPIWrapper(ydc_api_key="test", research_effort="deep")
+    wrapper.raw_research("test query")
+    body = json.loads(responses.calls[0].request.body)
+    assert body["research_effort"] == "deep"
+
+
+@responses.activate
+def test_research_effort_omitted_when_none() -> None:
+    responses.add(
+        responses.POST,
+        f"{TEST_RESEARCH_ENDPOINT}/v1/research",
+        json=MOCK_RESEARCH_RESPONSE,
+        status=200,
+    )
+    wrapper = YouSearchAPIWrapper(ydc_api_key="test")
+    wrapper.raw_research("test query")
+    body = json.loads(responses.calls[0].request.body)
+    assert "research_effort" not in body
+
+
+def test_format_research_response_no_sources() -> None:
+    raw: Dict[str, Any] = {
+        "output": {"content": "Short answer.", "content_type": "text", "sources": []}
+    }
+    result = YouSearchAPIWrapper._format_research_response(raw)
+    assert result == "Short answer."
+
+
+async def test_raw_research_async() -> None:
+    wrapper = YouSearchAPIWrapper(ydc_api_key="test")
+
+    mock_response = AsyncMock()
+    mock_response.__aenter__.return_value = mock_response
+    mock_response.__aexit__.return_value = None
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value=MOCK_RESEARCH_RESPONSE)
+    mock_response.raise_for_status = lambda: None
+
+    with patch("aiohttp.ClientSession.post", return_value=mock_response):
+        result = await wrapper.raw_research_async("quantum computing advances")
+        assert result == MOCK_RESEARCH_RESPONSE
+
+
+async def test_research_text_async() -> None:
+    wrapper = YouSearchAPIWrapper(ydc_api_key="test")
+
+    mock_response = AsyncMock()
+    mock_response.__aenter__.return_value = mock_response
+    mock_response.__aexit__.return_value = None
+    mock_response.status = 200
+    mock_response.json = AsyncMock(return_value=MOCK_RESEARCH_RESPONSE)
+    mock_response.raise_for_status = lambda: None
+
+    with patch("aiohttp.ClientSession.post", return_value=mock_response):
+        result = await wrapper.research_text_async("quantum computing advances")
+        assert result == MOCK_RESEARCH_TEXT


### PR DESCRIPTION
**Description:** Update the You.com integration to target the current v1 API endpoints, add support for the Contents API, and add the Research API.

**Search & Contents (v1 migration):**
- Migrate \`YouSearchAPIWrapper\` from \`api.ydc-index.io/search\` to \`ydc-index.io/v1/search\`, updating response parsing from \`hits[]\` to \`results.web[]\` / \`results.news[]\`
- Add new search parameters: \`count\`, \`freshness\`, \`offset\`, \`livecrawl\`, \`livecrawl_formats\`
- Add livecrawl content parsing (prefers markdown → html → snippets)
- Add \`contents()\` / \`contents_async()\` methods for the Contents API (\`POST /v1/contents\`)
- Add \`YouContentsTool\` for agent-based page content extraction with structured docstrings
- Deprecate removed parameters (\`num_web_results\`, \`n_hits\`, \`search_lang\`, \`ui_lang\`, \`spellcheck\`) and legacy \`endpoint_type\` values (\`"news"\`, \`"rag"\`, \`"snippet"\`) with \`DeprecationWarning\`
- Fix mutable state bug where \`endpoint_type="snippet"\` permanently mutated instance state
- Fix \`YouRetriever\` passing \`run_manager\` into \`**kwargs\`, which caused aiohttp to crash on async calls by attempting to serialize it as a query parameter
- Fix stale doc URLs and a typo in \`llms/you.py\`
- Remove unused internal Pydantic models (\`YouHitMetadata\`, \`YouHit\`, \`YouAPIOutput\`, \`YouDocument\`)

**Research API (new):**
- Add \`research_effort\` field to \`YouSearchAPIWrapper\` — one of \`"lite"\`, \`"standard"\`, \`"deep"\`, \`"exhaustive"\`
- Add \`raw_research()\` / \`raw_research_async()\` — call \`POST https://api.you.com/v1/research\` and return the raw response dict (note: separate base URL from search/contents)
- Add \`research_text()\` / \`research_text_async()\` — return a Markdown-formatted answer with a numbered \`## Sources\` section
- Add \`YouResearchTool\` — \`BaseTool\` subclass that wraps research methods for agent use, with sync and async support
- Export \`YouResearchTool\` from \`tools/you/__init__.py\`

**Issue:** N/A

**Dependencies:** None. No changes to \`pyproject.toml\`. Both \`requests\` and \`aiohttp\` are existing required deps.

---

**Compatibility:** All existing fields and behavior are preserved. Deprecated fields emit \`DeprecationWarning\` but continue to work. No breaking changes.

\`make format\`, \`make lint\`, and \`make test\` pass. 45 unit tests pass (41 original + 4 new for the retriever, 4 for tools, 7 for research wrapper, 3 for \`YouResearchTool\`). The 6 pre-existing failures in \`test_recursive_url_loader.py\` are unrelated to this change (ssl kwarg incompatibility in test mocks).

**Docs PR:** https://github.com/langchain-ai/docs/pull/2711

> AI agents were used to assist with the implementation of this contribution.