### PR TITLE
fix: address CodeQL alerts for URL validation and sensitive logging

### DIFF
--- a/libs/community/langchain_community/document_loaders/gutenberg.py
+++ b/libs/community/langchain_community/document_loaders/gutenberg.py
@@ -1,4 +1,5 @@
 from typing import List
+from urllib.parse import urlparse
 
 from langchain_core.documents import Document
 
@@ -10,7 +11,8 @@ class GutenbergLoader(BaseLoader):
 
     def __init__(self, file_path: str):
         """Initialize with a file path."""
-        if not file_path.startswith("https://www.gutenberg.org"):
+        parsed = urlparse(file_path)
+        if parsed.scheme != "https" or parsed.hostname != "www.gutenberg.org":
             raise ValueError("file path must start with 'https://www.gutenberg.org'")
 
         if not file_path.endswith(".txt"):

--- a/libs/community/langchain_community/utilities/clickup.py
+++ b/libs/community/langchain_community/utilities/clickup.py
@@ -1,6 +1,7 @@
 """Util that calls clickup."""
 
 import json
+import logging
 import warnings
 from dataclasses import asdict, dataclass, fields
 from typing import Any, Dict, List, Mapping, Optional, Tuple, Type, Union
@@ -8,6 +9,8 @@ from typing import Any, Dict, List, Mapping, Optional, Tuple, Type, Union
 import requests
 from langchain_core.utils import get_from_dict_or_env
 from pydantic import BaseModel, ConfigDict, model_validator
+
+logger = logging.getLogger(__name__)
 
 DEFAULT_URL = "https://api.clickup.com/api/v2"
 
@@ -311,12 +314,16 @@ class ClickupAPIWrapper(BaseModel):
         data = response.json()
 
         if "access_token" not in data:
-            print(f"Error: {data}")  # noqa: T201
+            logger.warning(
+                "Failed to retrieve access token: %s",
+                data.get("ECODE", "unknown error"),
+            )
             if "ECODE" in data and data["ECODE"] == "OAUTH_014":
                 url = ClickupAPIWrapper.get_access_code_url(oauth_client_id)
-                print(  # noqa: T201
-                    "You already used this code once. Generate a new one.",
-                    f"Our best guess for the url to get a new code is:\n{url}",
+                logger.warning(
+                    "You already used this code once. Generate a new one. "
+                    "Our best guess for the url to get a new code is:\n%s",
+                    url,
                 )
             return None
 


### PR DESCRIPTION
## Summary
- **gutenberg.py**: Replace `startswith` URL check with `urlparse` hostname validation to prevent SSRF via domain confusion (e.g. `gutenberg.org.evil.com`)
- **clickup.py**: Replace bare `print()` with `logger.warning()` to avoid clear-text logging of OAuth response data

Addresses CodeQL alerts #15 and #19. The remaining 4 alerts (#16, #17, #20, #21) were dismissed as false positives with explanations.

> This PR was authored with assistance from an AI agent (Claude Code).

## Test plan
- [x] Verified `GutenbergLoader` accepts valid `https://www.gutenberg.org` URLs
- [x] Verified `GutenbergLoader` rejects bypass URLs like `https://www.gutenberg.org.evil.com/malicious.txt`
- [x] Verified `ClickupAPIWrapper` imports cleanly with new logger
- [x] `ruff check` passes on both files

🤖 Generated with [Claude Code](https://claude.com/claude-code)