### PR TITLE
fix: code scanning alert no. 65: Clear-text logging of sensitive information

### DIFF
--- a/libs/community/langchain_community/utilities/clickup.py
+++ b/libs/community/langchain_community/utilities/clickup.py
@@ -319,11 +319,9 @@ class ClickupAPIWrapper(BaseModel):
                 data.get("ECODE", "unknown error"),
             )
             if "ECODE" in data and data["ECODE"] == "OAUTH_014":
-                url = ClickupAPIWrapper.get_access_code_url(oauth_client_id)
                 logger.warning(
-                    "You already used this code once. Generate a new one. "
-                    "Our best guess for the url to get a new code is:\n%s",
-                    url,
+                    "You already used this code once. Generate a new one via your "
+                    "ClickUp OAuth app settings and then retry with the new code."
                 )
             return None
 


### PR DESCRIPTION
Potential fix for [https://github.com/langchain-ai/langchain-community/security/code-scanning/65](https://github.com/langchain-ai/langchain-community/security/code-scanning/65)

To fix the problem, we should stop logging the URL that embeds the `oauth_client_id` directly. We want to preserve functionality: the method should still compute and return the correct URL, and in the error path we should still give helpful instructions without emitting the sensitive client ID.

The best minimal change is to modify the logging around the URL in `get_access_token`. In the `OAUTH_014` branch, instead of constructing the URL with `get_access_code_url` and logging that full URL, we can either (a) log a generic instructional message that explains how to regenerate a code without including any concrete URL, or (b) log a redacted placeholder version of the URL that does not contain the actual client ID. Since we must not log the tainted `oauth_client_id` and the URL is entirely derived from it, the simplest approach is to remove the use of `url` in that log call and provide a generic message.

Concretely, in `libs/community/langchain_community/utilities/clickup.py`:

- In `ClickupAPIWrapper.get_access_token`, in the `if "ECODE" in data and data["ECODE"] == "OAUTH_014":` block, remove the line that assigns `url = ClickupAPIWrapper.get_access_code_url(oauth_client_id)` and replace the subsequent `logger.warning` call with one that does not interpolate `url` (or the client id) at all. For example, log a static explanatory string about regenerating the authorization code via ClickUp’s OAuth settings.
- No new imports, methods, or other definitions are required.

This eliminates any clear‑text logging of the tainted `oauth_client_id` while keeping the rest of the behavior intact.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
