### PR TITLE
community: Add AlterLabLoader document loader

### DIFF
--- a/libs/community/langchain_community/document_loaders/__init__.py
+++ b/libs/community/langchain_community/document_loaders/__init__.py
@@ -38,6 +38,9 @@ if TYPE_CHECKING:
     from langchain_community.document_loaders.airtable import (
         AirtableLoader,
     )
+    from langchain_community.document_loaders.alterlab import (
+        AlterLabLoader,
+    )
     from langchain_community.document_loaders.apify_dataset import (
         ApifyDatasetLoader,
     )
@@ -547,6 +550,7 @@ _module_lookup = {
     "AirbyteTypeformLoader": "langchain_community.document_loaders.airbyte",
     "AirbyteZendeskSupportLoader": "langchain_community.document_loaders.airbyte",
     "AirtableLoader": "langchain_community.document_loaders.airtable",
+    "AlterLabLoader": "langchain_community.document_loaders.alterlab",
     "AmazonTextractPDFLoader": "langchain_community.document_loaders.pdf",
     "ApifyDatasetLoader": "langchain_community.document_loaders.apify_dataset",
     "ArcGISLoader": "langchain_community.document_loaders.arcgis_loader",
@@ -755,6 +759,7 @@ __all__ = [
     "AirbyteTypeformLoader",
     "AirbyteZendeskSupportLoader",
     "AirtableLoader",
+    "AlterLabLoader",
     "AmazonTextractPDFLoader",
     "ApifyDatasetLoader",
     "ArcGISLoader",

--- a/libs/community/langchain_community/document_loaders/alterlab.py
+++ b/libs/community/langchain_community/document_loaders/alterlab.py
@@ -1,0 +1,309 @@
+"""AlterLab document loader for LangChain.
+
+This module provides a document loader that uses the AlterLab API to scrape
+web pages and return them as LangChain Document objects with structured metadata.
+
+Setup:
+    Install ``alterlab`` and ``langchain-community``, then set your API key:
+
+    .. code-block:: bash
+
+        pip install -U alterlab langchain-community
+        export ALTERLAB_API_KEY="your-api-key"
+
+Instantiate:
+    .. code-block:: python
+
+        from langchain_community.document_loaders import AlterLabLoader
+
+        loader = AlterLabLoader(
+            url="https://example.com/article",
+        )
+
+Lazy load:
+    .. code-block:: python
+
+        docs = []
+        for doc in loader.lazy_load():
+            docs.append(doc)
+        print(docs[0].page_content[:100])
+        print(docs[0].metadata)
+
+Async load:
+    .. code-block:: python
+
+        docs = await loader.aload()
+        print(docs[0].page_content[:100])
+        print(docs[0].metadata)
+"""
+
+import logging
+import os
+from typing import Any, AsyncIterator, Dict, Iterator, List, Optional
+
+from langchain_core.document_loaders import BaseLoader
+from langchain_core.documents import Document
+
+logger = logging.getLogger(__name__)
+
+
+class AlterLabLoader(BaseLoader):
+    """Load web pages using the AlterLab scraping API.
+
+    AlterLab returns structured data with typed metadata (title, author,
+    published date, content type) and supports multiple output formats
+    optimized for LLM consumption.
+
+    Setup:
+        Install ``alterlab`` and set environment variable ``ALTERLAB_API_KEY``.
+
+        .. code-block:: bash
+
+            pip install -U alterlab langchain-community
+            export ALTERLAB_API_KEY="your-api-key"
+
+    Instantiate:
+        .. code-block:: python
+
+            from langchain_community.document_loaders import AlterLabLoader
+
+            # Single URL
+            loader = AlterLabLoader(
+                url="https://example.com/article",
+            )
+
+            # Multiple URLs
+            loader = AlterLabLoader(
+                urls=[
+                    "https://example.com/page1",
+                    "https://example.com/page2",
+                ],
+            )
+
+            # With custom parameters
+            loader = AlterLabLoader(
+                url="https://example.com",
+                params={
+                    "formats": ["markdown", "json"],
+                    "extraction_profile": "article",
+                },
+            )
+
+    Lazy load:
+        .. code-block:: python
+
+            docs = []
+            docs_lazy = loader.lazy_load()
+
+            for doc in docs_lazy:
+                docs.append(doc)
+            print(docs[0].page_content[:100])
+            print(docs[0].metadata)
+
+    Async load:
+        .. code-block:: python
+
+            docs = await loader.aload()
+            print(docs[0].page_content[:100])
+            print(docs[0].metadata)
+
+    Metadata fields:
+        - ``source``: The URL that was scraped
+        - ``title``: Page title (if detected)
+        - ``author``: Content author (if detected)
+        - ``published_at``: Publication date (if detected)
+        - ``status_code``: HTTP response status code
+        - ``extraction_method``: How content was extracted (e.g., "algorithmic", "playbook:amazon")
+        - ``response_time_ms``: API response time in milliseconds
+        - ``credits_used``: AlterLab credits consumed
+        - ``tier_used``: Scraping tier used (1=curl, 2=http, 3=stealth, 4=browser)
+
+    See https://docs.alterlab.io for full API documentation.
+    """  # noqa: E501
+
+    def __init__(
+        self,
+        url: Optional[str] = None,
+        *,
+        urls: Optional[List[str]] = None,
+        api_key: Optional[str] = None,
+        api_url: Optional[str] = None,
+        params: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        """Initialize AlterLabLoader.
+
+        Args:
+            url: Single URL to scrape.
+            urls: List of URLs to scrape. Cannot be used with ``url``.
+            api_key: AlterLab API key. Defaults to ``ALTERLAB_API_KEY``
+                environment variable.
+            api_url: AlterLab API base URL. Defaults to ``ALTERLAB_API_URL``
+                environment variable or ``https://api.alterlab.io``.
+            params: Additional parameters passed to the AlterLab scrape API.
+                See https://docs.alterlab.io for available options. Common
+                parameters include ``formats``, ``mode``, ``extraction_profile``,
+                ``extraction_schema``, ``advanced``, and ``cost_controls``.
+
+        Raises:
+            ImportError: If the ``alterlab`` package is not installed.
+            ValueError: If neither ``url`` nor ``urls`` is provided, or if both
+                are provided.
+        """
+        try:
+            import alterlab  # noqa: F401
+        except ImportError:
+            msg = (
+                "Could not import alterlab python package. "
+                "Please install it with `pip install alterlab`."
+            )
+            raise ImportError(msg)
+
+        if url and urls:
+            msg = "Provide either 'url' or 'urls', not both."
+            raise ValueError(msg)
+        if not url and not urls:
+            msg = "Either 'url' or 'urls' must be provided."
+            raise ValueError(msg)
+
+        self.api_key = api_key or os.getenv("ALTERLAB_API_KEY", "")
+        if not self.api_key:
+            msg = (
+                "AlterLab API key is required. Pass api_key or set the "
+                "ALTERLAB_API_KEY environment variable."
+            )
+            raise ValueError(msg)
+
+        self.api_url = (
+            api_url or os.getenv("ALTERLAB_API_URL") or "https://api.alterlab.io"
+        )
+        self.urls = urls if urls else [url]  # type: ignore[list-item]
+        self.params = params or {}
+
+    def lazy_load(self) -> Iterator[Document]:
+        """Load documents from AlterLab API synchronously.
+
+        Yields:
+            Document objects with page content and structured metadata.
+        """
+        from alterlab import AlterLabSync
+
+        client = AlterLabSync(api_key=self.api_key, base_url=self.api_url)
+        try:
+            for url in self.urls:
+                try:
+                    result = client.scrape(url, **self.params)
+                    doc = self._result_to_document(result, url)
+                    if doc:
+                        yield doc
+                except Exception as e:
+                    logger.warning("Failed to scrape %s: %s", url, e)
+                    continue
+        finally:
+            client.close()
+
+    async def alazy_load(self) -> AsyncIterator[Document]:
+        """Load documents from AlterLab API asynchronously.
+
+        Yields:
+            Document objects with page content and structured metadata.
+        """
+        from alterlab import AlterLab
+
+        async with AlterLab(api_key=self.api_key, base_url=self.api_url) as client:
+            for url in self.urls:
+                try:
+                    result = await client.scrape(url, **self.params)
+                    doc = self._result_to_document(result, url)
+                    if doc:
+                        yield doc
+                except Exception as e:
+                    logger.warning("Failed to scrape %s: %s", url, e)
+                    continue
+
+    @staticmethod
+    def _extract_page_content(result: Dict[str, Any]) -> str:
+        """Extract page content from API response.
+
+        Priority: markdown > text > html > raw content string.
+
+        Args:
+            result: AlterLab API response dictionary.
+
+        Returns:
+            Extracted content string, or empty string if no content found.
+        """
+        content = result.get("content")
+
+        # Multi-format response (dict with format keys)
+        if isinstance(content, dict):
+            # Prefer markdown for LLM consumption
+            if content.get("markdown"):
+                return content["markdown"]
+            if content.get("text"):
+                return content["text"]
+            if content.get("html"):
+                return content["html"]
+            # Empty dict or no usable format
+            return ""
+
+        # Legacy single-format response (string)
+        if isinstance(content, str):
+            return content
+
+        return ""
+
+    @staticmethod
+    def _result_to_document(
+        result: Dict[str, Any], source_url: str
+    ) -> Optional[Document]:
+        """Convert an AlterLab API response to a LangChain Document.
+
+        Args:
+            result: AlterLab API response dictionary.
+            source_url: The URL that was scraped.
+
+        Returns:
+            A Document with page_content and metadata, or None if no content.
+        """
+        page_content = AlterLabLoader._extract_page_content(result)
+        if not page_content:
+            return None
+
+        # Build metadata from response fields
+        metadata: Dict[str, Any] = {"source": result.get("url", source_url)}
+
+        # Content metadata
+        if result.get("title"):
+            metadata["title"] = result["title"]
+        if result.get("author"):
+            metadata["author"] = result["author"]
+        if result.get("published_at"):
+            metadata["published_at"] = result["published_at"]
+
+        # Technical metadata
+        if result.get("status_code") is not None:
+            metadata["status_code"] = result["status_code"]
+        if result.get("extraction_method"):
+            metadata["extraction_method"] = result["extraction_method"]
+        if result.get("response_time_ms") is not None:
+            metadata["response_time_ms"] = result["response_time_ms"]
+
+        # Billing metadata
+        billing = result.get("billing")
+        if isinstance(billing, dict):
+            if billing.get("total_credits") is not None:
+                metadata["credits_used"] = billing["total_credits"]
+            if billing.get("tier_used"):
+                metadata["tier_used"] = billing["tier_used"]
+        elif result.get("credits_used") is not None:
+            # Legacy response format
+            metadata["credits_used"] = result["credits_used"]
+
+        # Include any additional metadata from the API response
+        extra_meta = result.get("metadata")
+        if isinstance(extra_meta, dict):
+            for key, value in extra_meta.items():
+                if key not in metadata and value is not None:
+                    metadata[key] = value
+
+        return Document(page_content=page_content, metadata=metadata)

--- a/libs/community/tests/unit_tests/document_loaders/test_alterlab.py
+++ b/libs/community/tests/unit_tests/document_loaders/test_alterlab.py
@@ -1,0 +1,444 @@
+"""Tests for AlterLabLoader document loader."""
+
+import asyncio
+import sys
+from typing import Any, Dict, Generator, Tuple
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+from langchain_core.documents import Document
+
+
+# Mock alterlab module before importing AlterLabLoader
+@pytest.fixture(autouse=True)
+def mock_alterlab_module() -> (
+    Generator[Tuple[MagicMock, MagicMock, MagicMock], None, None]
+):
+    """Mock alterlab package in sys.modules for all tests."""
+    mock_module = MagicMock()
+    mock_sync_client = MagicMock()
+    mock_async_client = AsyncMock()
+
+    mock_module.AlterLabSync.return_value = mock_sync_client
+    mock_module.AlterLab.return_value = mock_async_client
+
+    sys.modules["alterlab"] = mock_module
+    yield mock_module, mock_sync_client, mock_async_client
+
+    if "alterlab" in sys.modules:
+        del sys.modules["alterlab"]
+
+
+from langchain_community.document_loaders.alterlab import AlterLabLoader  # noqa: E402
+
+_LOADER_INIT = (
+    "langchain_community.document_loaders"
+    ".alterlab.AlterLabLoader.__init__"
+)
+
+# ---------------------------------------------------------------------------
+# Fixtures & helpers
+# ---------------------------------------------------------------------------
+
+SAMPLE_SCRAPE_RESPONSE: Dict[str, Any] = {
+    "job_id": "job_abc123",
+    "url": "https://example.com/article",
+    "status_code": 200,
+    "content": {
+        "markdown": "# Example Article\n\nThis is the article body.",
+        "text": "Example Article. This is the article body.",
+        "html": "<h1>Example Article</h1><p>This is the article body.</p>",
+        "json": {
+            "title": "Example Article",
+            "body": "This is the article body.",
+        },
+    },
+    "title": "Example Article",
+    "author": "Jane Doe",
+    "published_at": "2026-01-15T10:00:00Z",
+    "metadata": {"language": "en", "content_type": "article"},
+    "headers": {"content-type": "text/html"},
+    "cached": False,
+    "response_time_ms": 450,
+    "size_bytes": 2048,
+    "billing": {
+        "total_credits": 2,
+        "tier_used": "2",
+        "escalations": [],
+        "savings": 0,
+    },
+    "extraction_method": "algorithmic",
+    "version": "v1",
+}
+
+SAMPLE_LEGACY_RESPONSE: Dict[str, Any] = {
+    "url": "https://example.com/page",
+    "status_code": 200,
+    "content": "This is plain text content from the page.",
+    "title": "Plain Page",
+    "author": None,
+    "published_at": None,
+    "metadata": None,
+    "headers": {"content-type": "text/html"},
+    "cached": True,
+    "credits_used": 1,
+    "response_time_ms": 120,
+    "size_bytes": 512,
+}
+
+SAMPLE_EMPTY_RESPONSE: Dict[str, Any] = {
+    "url": "https://example.com/empty",
+    "status_code": 200,
+    "content": {},
+    "title": None,
+    "metadata": None,
+    "headers": {},
+    "cached": False,
+    "response_time_ms": 50,
+    "size_bytes": 0,
+    "billing": {"total_credits": 1, "tier_used": "1", "escalations": [], "savings": 0},
+}
+
+
+@pytest.fixture
+def mock_alterlab_sync():
+    """Create a mock AlterLabSync client."""
+    mock_client = MagicMock()
+    mock_client.scrape.return_value = SAMPLE_SCRAPE_RESPONSE
+    mock_client.close = MagicMock()
+    mock_client.__enter__ = MagicMock(return_value=mock_client)
+    mock_client.__exit__ = MagicMock(return_value=False)
+    return mock_client
+
+
+@pytest.fixture
+def mock_alterlab_async():
+    """Create a mock AlterLab async client."""
+    mock_client = AsyncMock()
+    mock_client.scrape.return_value = SAMPLE_SCRAPE_RESPONSE
+    mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+    mock_client.__aexit__ = AsyncMock(return_value=False)
+    return mock_client
+
+
+# ---------------------------------------------------------------------------
+# Constructor tests
+# ---------------------------------------------------------------------------
+
+
+class TestAlterLabLoaderInit:
+    def test_init_with_url(self):
+        with patch.dict("os.environ", {"ALTERLAB_API_KEY": "sk_test_abc"}):
+            loader = AlterLabLoader(url="https://example.com")
+            assert loader.urls == ["https://example.com"]
+            assert loader.api_key == "sk_test_abc"
+            assert loader.api_url == "https://api.alterlab.io"
+            assert loader.params == {}
+
+    def test_init_with_urls(self):
+        with patch.dict("os.environ", {"ALTERLAB_API_KEY": "sk_test_abc"}):
+            urls = ["https://example.com/1", "https://example.com/2"]
+            loader = AlterLabLoader(urls=urls)
+            assert loader.urls == urls
+
+    def test_init_with_explicit_api_key(self):
+        loader = AlterLabLoader(url="https://example.com", api_key="sk_live_xyz")
+        assert loader.api_key == "sk_live_xyz"
+
+    def test_init_with_custom_api_url(self):
+        loader = AlterLabLoader(
+            url="https://example.com",
+            api_key="sk_test_abc",
+            api_url="https://custom.api.com",
+        )
+        assert loader.api_url == "https://custom.api.com"
+
+    def test_init_with_params(self):
+        loader = AlterLabLoader(
+            url="https://example.com",
+            api_key="sk_test_abc",
+            params={"formats": ["markdown", "json"], "mode": "js"},
+        )
+        assert loader.params == {"formats": ["markdown", "json"], "mode": "js"}
+
+    def test_init_requires_url_or_urls(self):
+        with pytest.raises(ValueError, match="Either 'url' or 'urls' must be provided"):
+            AlterLabLoader(api_key="sk_test_abc")
+
+    def test_init_rejects_both_url_and_urls(self):
+        with pytest.raises(
+            ValueError, match="Provide either 'url' or 'urls', not both"
+        ):
+            AlterLabLoader(
+                url="https://example.com",
+                urls=["https://example.com"],
+                api_key="sk_test_abc",
+            )
+
+    def test_init_requires_api_key(self):
+        with patch.dict("os.environ", {}, clear=True):
+            # Also clear ALTERLAB_API_KEY if it exists
+            import os
+
+            os.environ.pop("ALTERLAB_API_KEY", None)
+            with pytest.raises(ValueError, match="API key is required"):
+                AlterLabLoader(url="https://example.com")
+
+    def test_init_api_url_from_env(self):
+        with patch.dict(
+            "os.environ",
+            {
+                "ALTERLAB_API_KEY": "sk_test_abc",
+                "ALTERLAB_API_URL": "https://staging.alterlab.io",
+            },
+        ):
+            loader = AlterLabLoader(url="https://example.com")
+            assert loader.api_url == "https://staging.alterlab.io"
+
+
+# ---------------------------------------------------------------------------
+# Content extraction tests
+# ---------------------------------------------------------------------------
+
+
+class TestContentExtraction:
+    def test_extract_markdown_priority(self):
+        content = AlterLabLoader._extract_page_content(SAMPLE_SCRAPE_RESPONSE)
+        assert content == "# Example Article\n\nThis is the article body."
+
+    def test_extract_text_fallback(self):
+        result = {
+            "content": {
+                "text": "Fallback text",
+                "html": "<p>HTML</p>",
+            }
+        }
+        content = AlterLabLoader._extract_page_content(result)
+        assert content == "Fallback text"
+
+    def test_extract_html_fallback(self):
+        result = {"content": {"html": "<p>Only HTML</p>"}}
+        content = AlterLabLoader._extract_page_content(result)
+        assert content == "<p>Only HTML</p>"
+
+    def test_extract_legacy_string(self):
+        content = AlterLabLoader._extract_page_content(SAMPLE_LEGACY_RESPONSE)
+        assert content == "This is plain text content from the page."
+
+    def test_extract_empty_content(self):
+        content = AlterLabLoader._extract_page_content(SAMPLE_EMPTY_RESPONSE)
+        assert content == ""
+
+
+# ---------------------------------------------------------------------------
+# Document conversion tests
+# ---------------------------------------------------------------------------
+
+
+class TestResultToDocument:
+    def test_full_metadata(self):
+        doc = AlterLabLoader._result_to_document(
+            SAMPLE_SCRAPE_RESPONSE, "https://example.com/article"
+        )
+        assert doc is not None
+        assert doc.page_content == "# Example Article\n\nThis is the article body."
+        assert doc.metadata["source"] == "https://example.com/article"
+        assert doc.metadata["title"] == "Example Article"
+        assert doc.metadata["author"] == "Jane Doe"
+        assert doc.metadata["published_at"] == "2026-01-15T10:00:00Z"
+        assert doc.metadata["status_code"] == 200
+        assert doc.metadata["extraction_method"] == "algorithmic"
+        assert doc.metadata["response_time_ms"] == 450
+        assert doc.metadata["credits_used"] == 2
+        assert doc.metadata["tier_used"] == "2"
+        # Extra metadata merged
+        assert doc.metadata["language"] == "en"
+        assert doc.metadata["content_type"] == "article"
+
+    def test_legacy_response_metadata(self):
+        doc = AlterLabLoader._result_to_document(
+            SAMPLE_LEGACY_RESPONSE, "https://example.com/page"
+        )
+        assert doc is not None
+        assert doc.metadata["source"] == "https://example.com/page"
+        assert doc.metadata["title"] == "Plain Page"
+        assert doc.metadata["credits_used"] == 1
+        assert "author" not in doc.metadata
+        assert "tier_used" not in doc.metadata
+
+    def test_empty_content_returns_none(self):
+        doc = AlterLabLoader._result_to_document(
+            SAMPLE_EMPTY_RESPONSE, "https://example.com/empty"
+        )
+        assert doc is None
+
+    def test_source_url_fallback(self):
+        result = {
+            "content": "Some content",
+            "status_code": 200,
+            "headers": {},
+            "cached": False,
+            "response_time_ms": 100,
+            "size_bytes": 100,
+        }
+        doc = AlterLabLoader._result_to_document(result, "https://fallback.com")
+        assert doc is not None
+        assert doc.metadata["source"] == "https://fallback.com"
+
+
+# ---------------------------------------------------------------------------
+# Sync load tests
+# ---------------------------------------------------------------------------
+
+
+class TestLazyLoad:
+    def test_single_url(self, mock_alterlab_sync):
+        with patch(
+            _LOADER_INIT, return_value=None
+        ):
+            loader = AlterLabLoader.__new__(AlterLabLoader)
+            loader.urls = ["https://example.com/article"]
+            loader.api_key = "sk_test_abc"
+            loader.api_url = "https://api.alterlab.io"
+            loader.params = {}
+
+        with patch("alterlab.AlterLabSync", return_value=mock_alterlab_sync):
+            docs = list(loader.lazy_load())
+
+        assert len(docs) == 1
+        assert isinstance(docs[0], Document)
+        assert "Example Article" in docs[0].page_content
+        mock_alterlab_sync.scrape.assert_called_once_with("https://example.com/article")
+        mock_alterlab_sync.close.assert_called_once()
+
+    def test_multiple_urls(self, mock_alterlab_sync):
+        with patch(
+            _LOADER_INIT, return_value=None
+        ):
+            loader = AlterLabLoader.__new__(AlterLabLoader)
+            loader.urls = ["https://example.com/1", "https://example.com/2"]
+            loader.api_key = "sk_test_abc"
+            loader.api_url = "https://api.alterlab.io"
+            loader.params = {}
+
+        with patch("alterlab.AlterLabSync", return_value=mock_alterlab_sync):
+            docs = list(loader.lazy_load())
+
+        assert len(docs) == 2
+        assert mock_alterlab_sync.scrape.call_count == 2
+
+    def test_params_forwarded(self, mock_alterlab_sync):
+        with patch(
+            _LOADER_INIT, return_value=None
+        ):
+            loader = AlterLabLoader.__new__(AlterLabLoader)
+            loader.urls = ["https://example.com"]
+            loader.api_key = "sk_test_abc"
+            loader.api_url = "https://api.alterlab.io"
+            loader.params = {"formats": ["markdown"], "mode": "js"}
+
+        with patch("alterlab.AlterLabSync", return_value=mock_alterlab_sync):
+            list(loader.lazy_load())
+
+        mock_alterlab_sync.scrape.assert_called_once_with(
+            "https://example.com", formats=["markdown"], mode="js"
+        )
+
+    def test_scrape_error_continues(self, mock_alterlab_sync):
+        mock_alterlab_sync.scrape.side_effect = [
+            Exception("Network error"),
+            SAMPLE_SCRAPE_RESPONSE,
+        ]
+
+        with patch(
+            _LOADER_INIT, return_value=None
+        ):
+            loader = AlterLabLoader.__new__(AlterLabLoader)
+            loader.urls = ["https://fail.com", "https://example.com"]
+            loader.api_key = "sk_test_abc"
+            loader.api_url = "https://api.alterlab.io"
+            loader.params = {}
+
+        with patch("alterlab.AlterLabSync", return_value=mock_alterlab_sync):
+            docs = list(loader.lazy_load())
+
+        assert len(docs) == 1
+        assert docs[0].metadata["source"] == "https://example.com/article"
+
+
+# ---------------------------------------------------------------------------
+# Async load tests
+# ---------------------------------------------------------------------------
+
+
+class TestAsyncLoad:
+    def test_async_single_url(self, mock_alterlab_async):
+        with patch(
+            _LOADER_INIT, return_value=None
+        ):
+            loader = AlterLabLoader.__new__(AlterLabLoader)
+            loader.urls = ["https://example.com/article"]
+            loader.api_key = "sk_test_abc"
+            loader.api_url = "https://api.alterlab.io"
+            loader.params = {}
+
+        async def run():
+            with patch("alterlab.AlterLab", return_value=mock_alterlab_async):
+                docs = []
+                async for doc in loader.alazy_load():
+                    docs.append(doc)
+                return docs
+
+        docs = asyncio.get_event_loop().run_until_complete(run())
+        assert len(docs) == 1
+        assert isinstance(docs[0], Document)
+        assert "Example Article" in docs[0].page_content
+
+    def test_async_error_continues(self, mock_alterlab_async):
+        mock_alterlab_async.scrape.side_effect = [
+            Exception("Timeout"),
+            SAMPLE_SCRAPE_RESPONSE,
+        ]
+
+        with patch(
+            _LOADER_INIT, return_value=None
+        ):
+            loader = AlterLabLoader.__new__(AlterLabLoader)
+            loader.urls = ["https://fail.com", "https://example.com"]
+            loader.api_key = "sk_test_abc"
+            loader.api_url = "https://api.alterlab.io"
+            loader.params = {}
+
+        async def run():
+            with patch("alterlab.AlterLab", return_value=mock_alterlab_async):
+                docs = []
+                async for doc in loader.alazy_load():
+                    docs.append(doc)
+                return docs
+
+        docs = asyncio.get_event_loop().run_until_complete(run())
+        assert len(docs) == 1
+
+
+# ---------------------------------------------------------------------------
+# Integration-style tests (still mocked, but test the full load() path)
+# ---------------------------------------------------------------------------
+
+
+class TestLoadIntegration:
+    def test_load_returns_list(self, mock_alterlab_sync):
+        """Test that load() returns a list (provided by BaseLoader)."""
+        with patch(
+            _LOADER_INIT, return_value=None
+        ):
+            loader = AlterLabLoader.__new__(AlterLabLoader)
+            loader.urls = ["https://example.com"]
+            loader.api_key = "sk_test_abc"
+            loader.api_url = "https://api.alterlab.io"
+            loader.params = {}
+
+        with patch("alterlab.AlterLabSync", return_value=mock_alterlab_sync):
+            docs = loader.load()
+
+        assert isinstance(docs, list)
+        assert len(docs) == 1


### PR DESCRIPTION
## Description

Add `AlterLabLoader` — a document loader for the [AlterLab](https://alterlab.io) web scraping API.

AlterLab returns structured data with typed metadata (title, author, published date, content type) and supports multiple output formats optimized for LLM consumption. This gives RAG pipelines cleaner, more token-efficient input compared to raw HTML scrapers.

### Key differentiators vs existing loaders

| Feature | WebBaseLoader | FireCrawlLoader | AlterLabLoader |
|---------|--------------|-----------------|----------------|
| Output | Raw HTML | Markdown | Typed JSON fields |
| Metadata | URL only | Title, maybe description | Full typed fields (author, date, price, etc.) |
| Content detection | None | None | Auto-detects 16+ content types |
| Token efficiency | Worst (all page chrome) | Better (still has nav text) | Best (only extracted fields) |

### Features

- Single URL and batch URL loading
- Sync (`lazy_load`) and async (`alazy_load`) support
- Content priority: markdown > text > html
- Rich metadata extraction (source, title, author, dates, billing info)
- Configurable API parameters (formats, mode, extraction profiles)

### Dependencies

Requires the [`alterlab`](https://pypi.org/project/alterlab/) PyPI package (v2.0.1+).

### Tests

25 unit tests covering:
- Constructor validation (URL/API key handling, params)
- Content extraction priority (markdown > text > html > legacy string)
- Document conversion with full metadata mapping
- Sync and async loading paths
- Error handling (graceful skip on failure)

All tests use mocks — no network calls.

### AI Disclosure

This integration was developed with AI assistance (Claude) for code generation and testing.

## Issue

N/A (new integration)

## Twitter handle

@AlterlabIO