### PR TITLE
community: Add L402 Lightning payment tools

### DIFF
--- a/libs/community/langchain_community/tools/__init__.py
+++ b/libs/community/langchain_community/tools/__init__.py
@@ -170,6 +170,10 @@ if TYPE_CHECKING:
         JsonGetValueTool,
         JsonListKeysTool,
     )
+    from langchain_community.tools.l402.tool import (
+        L402FetchTool,
+        L402SpendingTool,
+    )
     from langchain_community.tools.merriam_webster.tool import (
         MerriamWebsterQueryRun,
     )
@@ -418,6 +422,8 @@ __all__ = [
     "JinaSearch",
     "JsonGetValueTool",
     "JsonListKeysTool",
+    "L402FetchTool",
+    "L402SpendingTool",
     "ListDirectoryTool",
     "ListPowerBITool",
     "ListSQLDatabaseTool",
@@ -569,6 +575,8 @@ _module_lookup = {
     "JinaSearch": "langchain_community.tools.jina_search.tool",
     "JsonGetValueTool": "langchain_community.tools.json.tool",
     "JsonListKeysTool": "langchain_community.tools.json.tool",
+    "L402FetchTool": "langchain_community.tools.l402.tool",
+    "L402SpendingTool": "langchain_community.tools.l402.tool",
     "ListDirectoryTool": "langchain_community.tools.file_management",
     "ListPowerBITool": "langchain_community.tools.powerbi.tool",
     "ListSQLDatabaseTool": "langchain_community.tools.sql_database.tool",

--- a/libs/community/langchain_community/tools/l402/__init__.py
+++ b/libs/community/langchain_community/tools/l402/__init__.py
@@ -1,0 +1,5 @@
+"""L402 Lightning payment tools."""
+
+from langchain_community.tools.l402.tool import L402FetchTool, L402SpendingTool
+
+__all__ = ["L402FetchTool", "L402SpendingTool"]

--- a/libs/community/langchain_community/tools/l402/tool.py
+++ b/libs/community/langchain_community/tools/l402/tool.py
@@ -1,0 +1,198 @@
+"""Tools for accessing L402-protected APIs with automatic Lightning payments.
+
+L402 is a protocol that uses HTTP 402 responses with Lightning Network invoices
+to enable machine-to-machine micropayments. These tools allow LangChain agents
+to automatically pay Lightning invoices when accessing L402-protected APIs.
+
+Setup:
+    Install ``l402-requests``:
+
+    .. code-block:: bash
+
+        pip install l402-requests
+
+    Set a wallet environment variable:
+
+    .. code-block:: bash
+
+        export STRIKE_API_KEY="your-key"  # or NWC_CONNECTION_STRING, LND_REST_HOST
+
+Usage:
+    .. code-block:: python
+
+        from langchain_community.tools.l402 import L402FetchTool, L402SpendingTool
+
+        tools = [L402FetchTool(), L402SpendingTool()]
+        agent = create_react_agent(llm, tools)
+"""
+
+from __future__ import annotations
+
+import json
+from typing import Any, Optional, Type
+
+from langchain_core.callbacks import CallbackManagerForToolRun
+from langchain_core.tools import BaseTool
+from pydantic import BaseModel, Field
+
+
+class _L402FetchInput(BaseModel):
+    """Input for L402FetchTool."""
+
+    url: str = Field(description="The full URL to request.")
+    method: str = Field(
+        default="GET",
+        description="HTTP method: GET or POST.",
+    )
+    body: Optional[str] = Field(
+        default=None,
+        description="JSON string body for POST requests.",
+    )
+
+
+class L402FetchTool(BaseTool):
+    """Fetch a URL that may require an L402 Lightning micropayment.
+
+    Automatically handles HTTP 402 responses by paying the Lightning invoice
+    and retrying with L402 credentials. Supports GET and POST.
+
+    Setup:
+        Install ``l402-requests``:
+
+        .. code-block:: bash
+
+            pip install l402-requests
+
+        Set a wallet environment variable:
+
+        .. code-block:: bash
+
+            export STRIKE_API_KEY="your-key"
+
+    Instantiate:
+        .. code-block:: python
+
+            from langchain_community.tools.l402 import L402FetchTool
+
+            tool = L402FetchTool()
+
+        With custom budget:
+
+        .. code-block:: python
+
+            from l402_requests import L402Client, BudgetController
+
+            client = L402Client(
+                budget=BudgetController(max_sats_per_request=500),
+            )
+            tool = L402FetchTool(l402_client=client)
+
+    Invoke:
+        .. code-block:: python
+
+            tool.invoke({"url": "https://l402.services/geoip/8.8.8.8"})
+    """
+
+    name: str = "l402_fetch"
+    description: str = (
+        "Fetch a URL that may be behind an L402 Lightning paywall. "
+        "If the server returns HTTP 402 (Payment Required), the Lightning "
+        "invoice is paid automatically and the request is retried. "
+        "Use this for any API that requires Lightning micropayments. "
+        "Supports GET and POST methods."
+    )
+    args_schema: Type[BaseModel] = _L402FetchInput
+
+    l402_client: Any = None
+    """Optional l402_requests.L402Client instance. If not provided,
+    a default client will be created using auto-detected wallet."""
+
+    def _get_client(self) -> Any:
+        try:
+            from l402_requests import L402Client
+        except ImportError:
+            raise ImportError(
+                "l402-requests is required for L402FetchTool. "
+                "Install it with: pip install l402-requests"
+            )
+        if self.l402_client is None:
+            self.l402_client = L402Client()
+        return self.l402_client
+
+    def _run(
+        self,
+        url: str,
+        method: str = "GET",
+        body: Optional[str] = None,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Fetch a URL with automatic L402 payment handling."""
+        client = self._get_client()
+        try:
+            if method.upper() == "POST":
+                json_body = json.loads(body) if body else None
+                response = client.post(url, json=json_body)
+            else:
+                response = client.get(url)
+
+            try:
+                data = response.json()
+                return json.dumps(data, indent=2)
+            except Exception:
+                return response.text[:4000]
+
+        except json.JSONDecodeError as e:
+            return f"Error: Invalid JSON body — {e}"
+        except Exception as e:
+            error_type = type(e).__name__
+            return f"Error: {error_type} — {e}"
+
+
+class L402SpendingTool(BaseTool):
+    """Check how many sats have been spent in this session.
+
+    Returns a summary of Lightning payments made so far including total sats
+    spent, per-domain breakdown, and hourly spending.
+
+    Setup:
+        Share the same client with ``L402FetchTool`` for accurate tracking:
+
+        .. code-block:: python
+
+            from l402_requests import L402Client
+            from langchain_community.tools.l402 import L402FetchTool, L402SpendingTool
+
+            client = L402Client()
+            tools = [L402FetchTool(l402_client=client), L402SpendingTool(l402_client=client)]
+    """
+
+    name: str = "l402_spending"
+    description: str = (
+        "Returns a summary of Lightning payments made so far: "
+        "total sats spent, payment count, and per-domain breakdown."
+    )
+
+    l402_client: Any = None
+    """Optional l402_requests.L402Client instance. Must be the same client
+    used by L402FetchTool for accurate spending tracking."""
+
+    def _run(
+        self,
+        run_manager: Optional[CallbackManagerForToolRun] = None,
+    ) -> str:
+        """Return spending summary."""
+        if self.l402_client is None:
+            return "No L402 client configured — pass the same client used by L402FetchTool."
+
+        log = self.l402_client.spending_log
+        total = log.total_spent()
+        if total == 0:
+            return "No L402 payments made yet."
+        return json.dumps(
+            {
+                "total_sats": total,
+                "spent_last_hour": log.spent_last_hour(),
+                "by_domain": log.by_domain(),
+            },
+            indent=2,
+        )

--- a/libs/community/langchain_community/tools/l402/tool.py
+++ b/libs/community/langchain_community/tools/l402/tool.py
@@ -127,8 +127,8 @@ class L402FetchTool(BaseTool):
         run_manager: Optional[CallbackManagerForToolRun] = None,
     ) -> str:
         """Fetch a URL with automatic L402 payment handling."""
-        client = self._get_client()
         try:
+            client = self._get_client()
             if method.upper() == "POST":
                 json_body = json.loads(body) if body else None
                 response = client.post(url, json=json_body)

--- a/libs/community/tests/unit_tests/tools/test_imports.py
+++ b/libs/community/tests/unit_tests/tools/test_imports.py
@@ -76,6 +76,8 @@ EXPECTED_ALL = [
     "JiraAction",
     "JsonGetValueTool",
     "JsonListKeysTool",
+    "L402FetchTool",
+    "L402SpendingTool",
     "ListDirectoryTool",
     "ListPowerBITool",
     "ListSQLDatabaseTool",

--- a/libs/community/tests/unit_tests/tools/test_l402.py
+++ b/libs/community/tests/unit_tests/tools/test_l402.py
@@ -1,8 +1,7 @@
 """Tests for L402 Lightning payment tools."""
 
+import json
 from unittest.mock import MagicMock, patch
-
-import pytest
 
 
 def test_l402_fetch_tool_import() -> None:
@@ -23,10 +22,9 @@ def test_l402_fetch_tool_metadata() -> None:
     """Test tool name and description."""
     from langchain_community.tools.l402 import L402FetchTool
 
-    with patch.dict("sys.modules", {"l402_requests": MagicMock()}):
-        tool = L402FetchTool()
-        assert tool.name == "l402_fetch"
-        assert "402" in tool.description or "L402" in tool.description
+    tool = L402FetchTool()
+    assert tool.name == "l402_fetch"
+    assert "402" in tool.description or "L402" in tool.description
 
 
 def test_l402_spending_tool_no_client() -> None:
@@ -45,12 +43,85 @@ def test_l402_fetch_tool_missing_dependency() -> None:
     tool = L402FetchTool()
 
     with patch.dict("sys.modules", {"l402_requests": None}):
-        with patch(
-            "langchain_community.tools.l402.tool.L402FetchTool._get_client",
-            side_effect=ImportError(
-                "l402-requests is required for L402FetchTool. "
-                "Install it with: pip install l402-requests"
-            ),
-        ):
-            result = tool._run(url="https://example.com")
-            assert "Error" in result
+        result = tool._run(url="https://example.com")
+        assert "Error" in result
+        assert "l402-requests" in result
+
+
+def test_l402_fetch_tool_get_success() -> None:
+    """Test GET request returns JSON response."""
+    from langchain_community.tools.l402 import L402FetchTool
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"data": "test"}
+
+    mock_client = MagicMock()
+    mock_client.get.return_value = mock_response
+
+    tool = L402FetchTool(l402_client=mock_client)
+    result = tool._run(url="https://example.com/api")
+
+    parsed = json.loads(result)
+    assert parsed == {"data": "test"}
+    mock_client.get.assert_called_once_with("https://example.com/api")
+
+
+def test_l402_fetch_tool_post_success() -> None:
+    """Test POST request with JSON body."""
+    from langchain_community.tools.l402 import L402FetchTool
+
+    mock_response = MagicMock()
+    mock_response.json.return_value = {"received": True}
+
+    mock_client = MagicMock()
+    mock_client.post.return_value = mock_response
+
+    tool = L402FetchTool(l402_client=mock_client)
+    result = tool._run(
+        url="https://example.com/api",
+        method="POST",
+        body='{"key": "value"}',
+    )
+
+    parsed = json.loads(result)
+    assert parsed == {"received": True}
+    mock_client.post.assert_called_once_with(
+        "https://example.com/api", json={"key": "value"}
+    )
+
+
+def test_l402_fetch_tool_text_fallback() -> None:
+    """Test non-JSON response falls back to text."""
+    from langchain_community.tools.l402 import L402FetchTool
+
+    mock_response = MagicMock()
+    mock_response.json.side_effect = ValueError("not JSON")
+    mock_response.text = "Hello plain text"
+
+    mock_client = MagicMock()
+    mock_client.get.return_value = mock_response
+
+    tool = L402FetchTool(l402_client=mock_client)
+    result = tool._run(url="https://example.com/text")
+
+    assert "Hello plain text" in result
+
+
+def test_l402_spending_tool_with_data() -> None:
+    """Test spending tool returns summary when payments have been made."""
+    from langchain_community.tools.l402 import L402SpendingTool
+
+    mock_log = MagicMock()
+    mock_log.total_spent.return_value = 500
+    mock_log.spent_last_hour.return_value = 500
+    mock_log.by_domain.return_value = {"api.example.com": 500}
+
+    mock_client = MagicMock()
+    mock_client.spending_log = mock_log
+
+    tool = L402SpendingTool(l402_client=mock_client)
+    result = tool._run()
+
+    parsed = json.loads(result)
+    assert parsed["total_sats"] == 500
+    assert parsed["by_domain"]["api.example.com"] == 500

--- a/libs/community/tests/unit_tests/tools/test_l402.py
+++ b/libs/community/tests/unit_tests/tools/test_l402.py
@@ -1,0 +1,56 @@
+"""Tests for L402 Lightning payment tools."""
+
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+
+def test_l402_fetch_tool_import() -> None:
+    """Test that L402FetchTool can be imported."""
+    from langchain_community.tools.l402 import L402FetchTool
+
+    assert L402FetchTool is not None
+
+
+def test_l402_spending_tool_import() -> None:
+    """Test that L402SpendingTool can be imported."""
+    from langchain_community.tools.l402 import L402SpendingTool
+
+    assert L402SpendingTool is not None
+
+
+def test_l402_fetch_tool_metadata() -> None:
+    """Test tool name and description."""
+    from langchain_community.tools.l402 import L402FetchTool
+
+    with patch.dict("sys.modules", {"l402_requests": MagicMock()}):
+        tool = L402FetchTool()
+        assert tool.name == "l402_fetch"
+        assert "402" in tool.description or "L402" in tool.description
+
+
+def test_l402_spending_tool_no_client() -> None:
+    """Test spending tool without client returns helpful message."""
+    from langchain_community.tools.l402 import L402SpendingTool
+
+    tool = L402SpendingTool()
+    result = tool._run()
+    assert "No L402 client" in result
+
+
+def test_l402_fetch_tool_missing_dependency() -> None:
+    """Test helpful error when l402-requests not installed."""
+    from langchain_community.tools.l402.tool import L402FetchTool
+
+    tool = L402FetchTool()
+
+    with patch.dict("sys.modules", {"l402_requests": None}):
+        with patch(
+            "langchain_community.tools.l402.tool.L402FetchTool._get_client",
+            side_effect=ImportError(
+                "l402-requests is required for L402FetchTool. "
+                "Install it with: pip install l402-requests"
+            ),
+        ):
+            result = tool._run(url="https://example.com")
+            assert "Error" in result


### PR DESCRIPTION
## Description

Adds `L402FetchTool` and `L402SpendingTool` for accessing L402-protected APIs with automatic Bitcoin Lightning micropayments.

[L402](https://docs.lightning.engineering/the-lightning-network/l402) is a protocol that extends HTTP 402 (Payment Required) with Lightning Network invoices, enabling machine-to-machine micropayments. When an agent hits an L402-protected API, the tool automatically pays the Lightning invoice and retries with credentials.

### New tools

- **`L402FetchTool`** — HTTP GET/POST with automatic L402 payment handling. Detects 402 responses, pays the Lightning invoice, retries with `Authorization: L402` credentials.
- **`L402SpendingTool`** — Returns a spending summary (total sats, per-domain breakdown, hourly spend).

### Dependencies

Uses [l402-requests](https://github.com/refined-element/l402-requests) (MIT, on PyPI) as an optional dependency — lazy-imported with a clear error message if not installed.

### Usage

```python
from langchain_community.tools.l402 import L402FetchTool, L402SpendingTool
from langgraph.prebuilt import create_react_agent

tools = [L402FetchTool(), L402SpendingTool()]
agent = create_react_agent(llm, tools)

result = agent.invoke({
    "messages": [("user", "Get the GeoIP data for 8.8.8.8 from l402.services")]
})
```

### Why this matters

L402 is gaining traction for AI agent commerce — agents can autonomously pay for API access with Bitcoin micropayments (typically 1-25 sats / $0.001-$0.025 per call). Multiple L402 services are live: [l402.services](https://l402.services), [agent-commerce.store](https://agent-commerce.store), [maximumsats.com](https://maximumsats.com).

### Files changed

- `libs/community/langchain_community/tools/l402/__init__.py` — Package init
- `libs/community/langchain_community/tools/l402/tool.py` — Tool implementations
- `libs/community/langchain_community/tools/__init__.py` — Register in TYPE_CHECKING, __all__, and _module_lookup
- `libs/community/tests/unit_tests/tools/test_l402.py` — Unit tests

### Tests

- Import tests
- Metadata validation
- Missing dependency handling
- Spending tool without client