### PR TITLE
Mask ChatOpenAI API key in repr output

### DIFF
--- a/libs/community/langchain_community/chat_models/openai.py
+++ b/libs/community/langchain_community/chat_models/openai.py
@@ -280,6 +280,14 @@ class ChatOpenAI(BaseChatModel):
         populate_by_name=True,
     )
 
+    def __repr_args__(self) -> Any:
+        """Mask API keys in repr to avoid accidental secret leakage in logs."""
+        for name, value in super().__repr_args__():
+            if name == "openai_api_key" and value:
+                yield (name, "**********")
+            else:
+                yield (name, value)
+
     @model_validator(mode="before")
     @classmethod
     def build_extra(cls, values: Dict[str, Any]) -> Any:

--- a/libs/community/tests/unit_tests/chat_models/test_openai.py
+++ b/libs/community/tests/unit_tests/chat_models/test_openai.py
@@ -1,0 +1,40 @@
+from langchain_community.chat_models.openai import ChatOpenAI
+
+
+def test_openai_api_key_repr_masked() -> None:
+    chat = ChatOpenAI.model_construct(
+        openai_api_key="sk-test-key",
+        model_name="gpt-4o-mini",
+        model_kwargs={},
+        streaming=False,
+        n=1,
+        temperature=0.7,
+    )
+
+    assert "sk-test-key" not in repr(chat)
+    assert "openai_api_key='**********'" in repr(chat)
+
+
+def test_client_params_uses_unmasked_secret_value_when_needed() -> None:
+    chat = ChatOpenAI.model_construct(
+        openai_api_key="sk-test-key",
+        openai_api_base="https://example.test",
+        openai_organization="org-test",
+        model_name="gpt-4o-mini",
+        model_kwargs={},
+        streaming=False,
+        n=1,
+        temperature=0.7,
+    )
+
+    # This code path is used for openai<1 compatibility.
+    from langchain_community.chat_models import openai as openai_module
+
+    original = openai_module.is_openai_v1
+    openai_module.is_openai_v1 = lambda: False
+    try:
+        params = chat._client_params
+    finally:
+        openai_module.is_openai_v1 = original
+
+    assert params["api_key"] == "sk-test-key"


### PR DESCRIPTION
## Summary
- mask `openai_api_key` in `ChatOpenAI` string representations so logs do not expose raw secrets
- keep the field type as `str` for compatibility with existing subclasses and call paths
- add focused unit tests that verify the repr is masked and runtime client params still receive the real key value

## Why
`repr(ChatOpenAI(...))` currently includes the plain API key. That can leak credentials into logs and error reports.

## Changes
- override `__repr_args__` in `ChatOpenAI` to replace any non-empty `openai_api_key` with `**********` in repr output
- add `tests/unit_tests/chat_models/test_openai.py`:
  - verifies the raw key is not present in repr
  - verifies `_client_params` still carries the original key where required

## Testing
- `python3 -m py_compile langchain_community/chat_models/openai.py tests/unit_tests/chat_models/test_openai.py`
- full pytest run is not available in this local environment because test dependencies (for example `blockbuster`) are missing

Fixes #535
