### PR TITLE
test(graphs): fix Ontotext GraphDB test scripts

### DIFF
--- a/libs/community/tests/integration_tests/chains/test_graph_database_sparql.py
+++ b/libs/community/tests/integration_tests/chains/test_graph_database_sparql.py
@@ -10,7 +10,7 @@ from langchain_community.chains.graph_qa.sparql import GraphSparqlQAChain
 from langchain_community.graphs import RdfGraph
 
 """
-cd libs/langchain/tests/integration_tests/chains/docker-compose-ontotext-graphdb
+cd libs/community/tests/integration_tests/graphs/docker-compose-ontotext-graphdb
 ./start.sh
 """
 

--- a/libs/community/tests/integration_tests/chains/test_ontotext_graphdb_qa.py
+++ b/libs/community/tests/integration_tests/chains/test_ontotext_graphdb_qa.py
@@ -7,7 +7,7 @@ from langchain_community.chains.graph_qa.ontotext_graphdb import OntotextGraphDB
 from langchain_community.graphs import OntotextGraphDBGraph
 
 """
-cd libs/langchain/tests/integration_tests/chains/docker-compose-ontotext-graphdb
+cd libs/community/tests/integration_tests/graphs/docker-compose-ontotext-graphdb
 ./start.sh
 """
 

--- a/libs/community/tests/integration_tests/graphs/docker-compose-ontotext-graphdb/start.sh
+++ b/libs/community/tests/integration_tests/graphs/docker-compose-ontotext-graphdb/start.sh
@@ -1,3 +1,5 @@
+#!/bin/bash
+
 set -ex
 
 docker compose down -v --remove-orphans


### PR DESCRIPTION
## Summary
- add a bash shebang to the moved Ontotext GraphDB `start.sh` helper
- update the stale inline setup instructions in the SPARQL/QA integration tests to the current `libs/community/...` fixture path

## Why
- the Ontotext GraphDB fixture was moved from the `langchain` repo to `langchain-community`, but two integration tests still pointed reviewers at the deleted old path
- `start.sh` had no shebang, so `shellcheck` reported `SC2148` and the script intent was ambiguous

## Testing
- `shellcheck libs/community/tests/integration_tests/graphs/docker-compose-ontotext-graphdb/start.sh libs/community/tests/integration_tests/graphs/docker-compose-ontotext-graphdb/graphdb_create.sh`
- `bash -n libs/community/tests/integration_tests/graphs/docker-compose-ontotext-graphdb/start.sh libs/community/tests/integration_tests/graphs/docker-compose-ontotext-graphdb/graphdb_create.sh`

## AI involvement
- This PR was prepared with AI agent assistance. I verified the moved fixture path locally and kept the change limited to the current GraphDB helper and test instructions.

## Review notes
- The only executable change is the shebang addition in `start.sh`.
- The two Python test file edits only update the copied setup instructions to the current fixture location.