### PR TITLE
community: add AnybrowseLoader document loader

### DIFF
--- a/libs/community/langchain_community/document_loaders/anybrowse.py
+++ b/libs/community/langchain_community/document_loaders/anybrowse.py
@@ -1,0 +1,104 @@
+"""Anybrowse document loader."""
+from __future__ import annotations
+
+from typing import Iterator, List, Optional
+
+import requests
+
+from langchain_core.documents import Document
+
+from langchain_community.document_loaders.base import BaseLoader
+
+
+class AnybrowseLoader(BaseLoader):
+    """Load web pages using the `Anybrowse` scraping service.
+
+    Anybrowse (https://anybrowse.dev) converts any URL to clean markdown,
+    handling JavaScript-rendered pages and Cloudflare-protected sites via
+    a multi-tier residential IP fallback pool.
+
+    Setup:
+        Optional API key at https://anybrowse.dev (50 requests/day free).
+        Anonymous use: 10 calls/day, no API key required.
+
+        .. code-block:: bash
+
+            pip install -U langchain-community requests
+
+    Instantiate:
+        .. code-block:: python
+
+            from langchain_community.document_loaders import AnybrowseLoader
+
+            loader = AnybrowseLoader(
+                urls=["https://example.com"],
+                api_key="ab_your_key_here",  # optional
+            )
+
+    Load:
+        .. code-block:: python
+
+            docs = loader.load()
+            print(docs[0].page_content[:200])
+
+    Attributes:
+        urls: List of URLs to scrape.
+        api_key: Optional Anybrowse API key.
+        timeout: HTTP request timeout in seconds.
+    """
+
+    BASE_URL: str = "https://anybrowse.dev/scrape"
+
+    def __init__(
+        self,
+        urls: List[str],
+        api_key: Optional[str] = None,
+        timeout: int = 30,
+    ) -> None:
+        """Initialize AnybrowseLoader.
+
+        Args:
+            urls: List of URLs to scrape.
+            api_key: Optional API key for higher rate limits.
+                     Get one free at https://anybrowse.dev.
+            timeout: HTTP request timeout in seconds. Default: 30.
+        """
+        self.urls = urls
+        self.api_key = api_key
+        self.timeout = timeout
+
+    def lazy_load(self) -> Iterator[Document]:
+        """Lazily load documents from URLs.
+
+        Yields:
+            Document objects with markdown content and metadata.
+
+        Raises:
+            ValueError: If the HTTP request fails.
+        """
+        headers: dict = {"Content-Type": "application/json"}
+        if self.api_key:
+            headers["Authorization"] = f"Bearer {self.api_key}"
+
+        for url in self.urls:
+            try:
+                response = requests.post(
+                    self.BASE_URL,
+                    json={"url": url},
+                    headers=headers,
+                    timeout=self.timeout,
+                )
+                response.raise_for_status()
+            except requests.RequestException as e:
+                raise ValueError(f"Failed to scrape {url}: {e}") from e
+
+            data = response.json()
+            if data.get("status") == "success" and data.get("markdown"):
+                yield Document(
+                    page_content=data["markdown"],
+                    metadata={
+                        "source": url,
+                        "title": data.get("title", ""),
+                        "scraper": "anybrowse",
+                    },
+                )


### PR DESCRIPTION
## Description

Adds `AnybrowseLoader` — a document loader that uses the [Anybrowse](https://anybrowse.dev) web scraping service to convert any URL to clean markdown.

**Key features:**
- Handles JavaScript-rendered pages via real Chrome browser
- Bypasses Cloudflare and bot-protected sites via residential IP fallback (50-worker pool)
- Returns clean markdown ready for LLM context
- Free tier: 10 calls/day with no API key; optional API key for higher limits

**Dependencies:** `requests` (already a langchain-community dependency)

**Usage:**
```python
from langchain_community.document_loaders import AnybrowseLoader

loader = AnybrowseLoader(
    urls=["https://example.com", "https://cloudflare-protected.com"],
    api_key="ab_your_key_here",  # optional, 10 free calls/day without
)
docs = loader.load()
```

**Links:**
- Website: https://anybrowse.dev
- GitHub: https://github.com/kc23go/anybrowse
- npm MCP server: `npx @anybrowse/mcp`

## Checklist
- [x] Lint and test
- [x] Added docstring with examples
- [x] No new required dependencies
