### PR TITLE
fix(sql): validate table access in QuerySQLDatabaseTool

### DIFF
--- a/libs/community/langchain_community/tools/sql_database/tool.py
+++ b/libs/community/langchain_community/tools/sql_database/tool.py
@@ -1,7 +1,7 @@
 # flake8: noqa
 """Tools for interacting with a SQL database."""
 
-from typing import Any, Dict, Optional, Sequence, Type, Union
+from typing import Any, Dict, Optional, Sequence, Set, Type, Union
 
 from sqlalchemy.engine import Result
 
@@ -17,6 +17,34 @@ from langchain_core.prompts import PromptTemplate
 from langchain_community.utilities.sql_database import SQLDatabase
 from langchain_core.tools import BaseTool
 from langchain_community.tools.sql_database.prompt import QUERY_CHECKER
+
+
+def _extract_table_names(query: str, dialect: Optional[str] = None) -> Set[str]:
+    """Extract table names from a SQL query using sqlglot.
+
+    Args:
+        query: The SQL query string to parse.
+        dialect: Optional SQL dialect for parsing.
+
+    Returns:
+        A set of table names referenced in the query.
+
+    Raises:
+        ValueError: If the query cannot be parsed.
+    """
+    try:
+        import sqlglot
+        from sqlglot import errors, exp
+    except ImportError as e:
+        msg = "sqlglot is required for table validation. Install with: pip install sqlglot"
+        raise ImportError(msg) from e
+
+    try:
+        parsed = sqlglot.parse_one(query, dialect=dialect)
+    except errors.ParseError as e:
+        raise ValueError(f"Invalid SQL query: {e}") from e
+
+    return {table.name for table in parsed.find_all(exp.Table) if table.name}
 
 
 class BaseSQLDatabaseTool(BaseModel):
@@ -50,12 +78,43 @@ class QuerySQLDatabaseTool(BaseSQLDatabaseTool, BaseTool):
     """
     args_schema: Type[BaseModel] = _QuerySQLDatabaseToolInput
 
+    def _validate_query_tables(self, query: str) -> Optional[str]:
+        """Validate that the query only accesses allowed tables.
+
+        Args:
+            query: The SQL query to validate.
+
+        Returns:
+            An error message if validation fails, None otherwise.
+        """
+        # If no table restrictions are configured, skip validation
+        if not self.db._ignore_tables and not self.db._include_tables:
+            return None
+
+        try:
+            query_tables = _extract_table_names(query, dialect=self.db.dialect)
+        except ValueError as e:
+            return f"Error: {e}"
+
+        usable_tables = set(self.db.get_usable_table_names())
+        disallowed_tables = query_tables - usable_tables
+
+        if disallowed_tables:
+            return (
+                f"Error: Access to table(s) {disallowed_tables} is not allowed. "
+                f"Allowed tables are: {sorted(usable_tables)}"
+            )
+        return None
+
     def _run(
         self,
         query: str,
         run_manager: Optional[CallbackManagerForToolRun] = None,
     ) -> Union[str, Sequence[Dict[str, Any]], Result]:
         """Execute the query, return the results or an error message."""
+        validation_error = self._validate_query_tables(query)
+        if validation_error:
+            return validation_error
         return self.db.run_no_throw(query)
 
 

--- a/libs/community/pyproject.toml
+++ b/libs/community/pyproject.toml
@@ -57,6 +57,7 @@ test = [
     "langchain-tests>=1.0.0,<2.0.0",
     "toml>=0.10.2,<1.0.0",
     "mypy-extensions>=1.0.0",
+    "sqlglot>=26.0.0,<27.0.0",
 ]
 test_integration = ["vcrpy>=6.0.0"]
 lint = [

--- a/libs/community/tests/unit_tests/test_dependencies.py
+++ b/libs/community/tests/unit_tests/test_dependencies.py
@@ -82,6 +82,8 @@ def test_test_group_dependencies(uv_conf: Mapping[str, Any]) -> None:
             # TODO: Hack to get around cffi 1.17.1 not working with py3.9, remove when
             # fix is released.
             "cffi",
+            # Required for QuerySQLDatabaseTool table validation tests
+            "sqlglot",
         ]
     )
 

--- a/libs/community/tests/unit_tests/tools/sql_database/test_tool.py
+++ b/libs/community/tests/unit_tests/tools/sql_database/test_tool.py
@@ -1,0 +1,251 @@
+"""Tests for SQL database tools."""
+
+import pytest
+import sqlalchemy as sa
+from sqlalchemy import Column, Integer, MetaData, String, Table, insert
+
+from langchain_community.tools.sql_database.tool import (
+    InfoSQLDatabaseTool,
+    ListSQLDatabaseTool,
+    QuerySQLDatabaseTool,
+    _extract_table_names,
+)
+from langchain_community.utilities.sql_database import SQLDatabase
+
+metadata_obj = MetaData()
+
+public_table = Table(
+    "public_data",
+    metadata_obj,
+    Column("id", Integer, primary_key=True),
+    Column("name", String(50)),
+)
+
+sensitive_table = Table(
+    "sensitive_data",
+    metadata_obj,
+    Column("id", Integer, primary_key=True),
+    Column("secret", String(100)),
+)
+
+
+@pytest.fixture
+def engine() -> sa.engine.Engine:
+    """Create an in-memory SQLite database with test tables."""
+    engine = sa.create_engine("sqlite:///:memory:")
+    metadata_obj.create_all(engine)
+
+    # Insert test data
+    with engine.begin() as conn:
+        conn.execute(insert(public_table).values(id=1, name="public_value"))
+        conn.execute(insert(sensitive_table).values(id=1, secret="secret_value"))
+
+    return engine
+
+
+@pytest.fixture
+def db_with_ignored_table(engine: sa.engine.Engine) -> SQLDatabase:
+    """Create SQLDatabase with sensitive_data in ignore_tables."""
+    return SQLDatabase(engine, ignore_tables=["sensitive_data"])
+
+
+@pytest.fixture
+def db_with_include_tables(engine: sa.engine.Engine) -> SQLDatabase:
+    """Create SQLDatabase with only public_data in include_tables."""
+    return SQLDatabase(engine, include_tables=["public_data"])
+
+
+@pytest.fixture
+def db_unrestricted(engine: sa.engine.Engine) -> SQLDatabase:
+    """Create SQLDatabase with no table restrictions."""
+    return SQLDatabase(engine)
+
+
+class TestExtractTableNames:
+    """Tests for the table extraction function."""
+
+    def test_simple_select(self) -> None:
+        query = "SELECT * FROM users"
+        assert _extract_table_names(query) == {"users"}
+
+    def test_select_with_join(self) -> None:
+        query = "SELECT * FROM users JOIN orders ON users.id = orders.user_id"
+        assert _extract_table_names(query) == {"users", "orders"}
+
+    def test_multiple_joins(self) -> None:
+        query = """
+            SELECT * FROM users
+            LEFT JOIN orders ON users.id = orders.user_id
+            INNER JOIN products ON orders.product_id = products.id
+        """
+        assert _extract_table_names(query) == {"users", "orders", "products"}
+
+    def test_insert_into(self) -> None:
+        query = "INSERT INTO users (name) VALUES ('test')"
+        assert _extract_table_names(query) == {"users"}
+
+    def test_update(self) -> None:
+        query = "UPDATE users SET name = 'test' WHERE id = 1"
+        assert _extract_table_names(query) == {"users"}
+
+    def test_delete(self) -> None:
+        query = "DELETE FROM users WHERE id = 1"
+        assert _extract_table_names(query) == {"users"}
+
+    def test_schema_qualified_table(self) -> None:
+        query = "SELECT * FROM public.users"
+        assert _extract_table_names(query) == {"users"}
+
+    def test_quoted_table_names(self) -> None:
+        query = 'SELECT * FROM "users"'
+        assert _extract_table_names(query) == {"users"}
+
+    def test_case_preserving(self) -> None:
+        query = "select * from USERS join ORDERS on users.id = orders.user_id"
+        assert _extract_table_names(query) == {"USERS", "ORDERS"}
+
+    def test_with_comments(self) -> None:
+        query = """
+            -- This is a comment
+            SELECT * FROM users
+            /* multi-line
+               comment */
+            JOIN orders ON users.id = orders.user_id
+        """
+        assert _extract_table_names(query) == {"users", "orders"}
+
+    def test_subquery(self) -> None:
+        query = """
+            SELECT * FROM users
+            WHERE id IN (SELECT user_id FROM orders)
+        """
+        assert _extract_table_names(query) == {"users", "orders"}
+
+    def test_invalid_sql_raises_value_error(self) -> None:
+        """Test that invalid SQL raises ValueError."""
+        query = "THIS IS NOT VALID SQL AT ALL @@##$$"
+        with pytest.raises(ValueError, match="Invalid SQL query"):
+            _extract_table_names(query)
+
+
+class TestQuerySQLDatabaseToolValidation:
+    """Tests for QuerySQLDatabaseTool table validation."""
+
+    def test_query_allowed_table_with_ignore_tables(
+        self, db_with_ignored_table: SQLDatabase
+    ) -> None:
+        """Test that querying an allowed table succeeds."""
+        tool = QuerySQLDatabaseTool(db=db_with_ignored_table)
+        result = tool.run("SELECT * FROM public_data")
+        assert "public_value" in str(result)
+        assert "Error" not in str(result)
+
+    def test_query_ignored_table_blocked(
+        self, db_with_ignored_table: SQLDatabase
+    ) -> None:
+        """Test that querying an ignored table is blocked."""
+        tool = QuerySQLDatabaseTool(db=db_with_ignored_table)
+        result = tool.run("SELECT * FROM sensitive_data")
+        assert "Error" in str(result)
+        assert "not allowed" in str(result)
+        assert "sensitive_data" in str(result)
+
+    def test_query_allowed_table_with_include_tables(
+        self, db_with_include_tables: SQLDatabase
+    ) -> None:
+        """Test that querying an included table succeeds."""
+        tool = QuerySQLDatabaseTool(db=db_with_include_tables)
+        result = tool.run("SELECT * FROM public_data")
+        assert "public_value" in str(result)
+        assert "Error" not in str(result)
+
+    def test_query_excluded_table_blocked_with_include_tables(
+        self, db_with_include_tables: SQLDatabase
+    ) -> None:
+        """Test that querying a non-included table is blocked."""
+        tool = QuerySQLDatabaseTool(db=db_with_include_tables)
+        result = tool.run("SELECT * FROM sensitive_data")
+        assert "Error" in str(result)
+        assert "not allowed" in str(result)
+
+    def test_query_with_join_blocked_if_any_table_restricted(
+        self, db_with_ignored_table: SQLDatabase
+    ) -> None:
+        """Test that a JOIN query is blocked if any table is restricted."""
+        tool = QuerySQLDatabaseTool(db=db_with_ignored_table)
+        query = (
+            "SELECT * FROM public_data "
+            "JOIN sensitive_data ON public_data.id = sensitive_data.id"
+        )
+        result = tool.run(query)
+        assert "Error" in str(result)
+        assert "not allowed" in str(result)
+
+    def test_unrestricted_db_allows_all_queries(
+        self, db_unrestricted: SQLDatabase
+    ) -> None:
+        """Test that a database with no restrictions allows all queries."""
+        tool = QuerySQLDatabaseTool(db=db_unrestricted)
+        result = tool.run("SELECT * FROM sensitive_data")
+        assert "secret_value" in str(result)
+        assert "Error" not in str(result)
+
+    def test_exact_table_name_matching(
+        self, db_with_ignored_table: SQLDatabase
+    ) -> None:
+        """Test that table name matching is exact (case-sensitive)."""
+        tool = QuerySQLDatabaseTool(db=db_with_ignored_table)
+        # Exact match should be blocked
+        result = tool.run("SELECT * FROM sensitive_data")
+        assert "Error" in str(result)
+        assert "not allowed" in str(result)
+
+    def test_invalid_sql_returns_error(
+        self, db_with_ignored_table: SQLDatabase
+    ) -> None:
+        """Test that invalid SQL returns an error message."""
+        tool = QuerySQLDatabaseTool(db=db_with_ignored_table)
+        result = tool.run("THIS IS NOT VALID SQL AT ALL @@##$$")
+        assert "Error" in str(result)
+        assert "Invalid SQL query" in str(result)
+
+
+class TestListSQLDatabaseTool:
+    """Tests for ListSQLDatabaseTool respecting table restrictions."""
+
+    def test_list_tables_excludes_ignored(
+        self, db_with_ignored_table: SQLDatabase
+    ) -> None:
+        """Test that ignored tables are not listed."""
+        tool = ListSQLDatabaseTool(db=db_with_ignored_table)
+        result = tool.run("")
+        assert "public_data" in result
+        assert "sensitive_data" not in result
+
+    def test_list_tables_only_includes_specified(
+        self, db_with_include_tables: SQLDatabase
+    ) -> None:
+        """Test that only included tables are listed."""
+        tool = ListSQLDatabaseTool(db=db_with_include_tables)
+        result = tool.run("")
+        assert "public_data" in result
+        assert "sensitive_data" not in result
+
+
+class TestInfoSQLDatabaseTool:
+    """Tests for InfoSQLDatabaseTool respecting table restrictions."""
+
+    def test_info_allowed_table(self, db_with_ignored_table: SQLDatabase) -> None:
+        """Test getting info for an allowed table."""
+        tool = InfoSQLDatabaseTool(db=db_with_ignored_table)
+        result = tool.run("public_data")
+        assert "public_data" in result
+        assert "Error" not in result
+
+    def test_info_ignored_table_blocked(
+        self, db_with_ignored_table: SQLDatabase
+    ) -> None:
+        """Test that getting info for an ignored table returns an error."""
+        tool = InfoSQLDatabaseTool(db=db_with_ignored_table)
+        result = tool.run("sensitive_data")
+        assert "Error" in result

--- a/libs/community/uv.lock
+++ b/libs/community/uv.lock
@@ -1613,6 +1613,7 @@ test = [
     { name = "pytest-xdist" },
     { name = "requests-mock" },
     { name = "responses" },
+    { name = "sqlglot" },
     { name = "syrupy" },
     { name = "toml" },
 ]
@@ -1680,6 +1681,7 @@ test = [
     { name = "pytest-xdist", specifier = ">=3.6.1,<4.0.0" },
     { name = "requests-mock", specifier = ">=1.11.0,<2.0.0" },
     { name = "responses", specifier = ">=0.22.0,<1.0.0" },
+    { name = "sqlglot", specifier = ">=26.0.0,<27.0.0" },
     { name = "syrupy", specifier = ">=4.0.2,<5.0.0" },
     { name = "toml", specifier = ">=0.10.2,<1.0.0" },
 ]
@@ -3855,6 +3857,15 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/0e/db/cafdeca5ecdaa3bb0811ba5449501da677ce0d83be8d05c5822da72d2e86/sqlalchemy-2.0.47-cp314-cp314t-win32.whl", hash = "sha256:c200db1128d72a71dc3c31c24b42eb9fd85b2b3e5a3c9ba1e751c11ac31250ff", size = 2147164, upload-time = "2026-02-24T17:14:40.783Z" },
     { url = "https://files.pythonhosted.org/packages/fc/5e/ff41a010e9e0f76418b02ad352060a4341bb15f0af66cedc924ab376c7c6/sqlalchemy-2.0.47-cp314-cp314t-win_amd64.whl", hash = "sha256:669837759b84e575407355dcff912835892058aea9b80bd1cb76d6a151cf37f7", size = 2182154, upload-time = "2026-02-24T17:14:43.205Z" },
     { url = "https://files.pythonhosted.org/packages/15/9f/7c378406b592fcf1fc157248607b495a40e3202ba4a6f1372a2ba6447717/sqlalchemy-2.0.47-py3-none-any.whl", hash = "sha256:e2647043599297a1ef10e720cf310846b7f31b6c841fee093d2b09d81215eb93", size = 1940159, upload-time = "2026-02-24T17:15:07.158Z" },
+]
+
+[[package]]
+name = "sqlglot"
+version = "26.33.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/25/9d/fcd59b4612d5ad1e2257c67c478107f073b19e1097d3bfde2fb517884416/sqlglot-26.33.0.tar.gz", hash = "sha256:2817278779fa51d6def43aa0d70690b93a25c83eb18ec97130fdaf707abc0d73", size = 5353340, upload-time = "2025-07-01T13:09:06.311Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/31/8d/f1d9cb5b18e06aa45689fbeaaea6ebab66d5f01d1e65029a8f7657c06be5/sqlglot-26.33.0-py3-none-any.whl", hash = "sha256:031cee20c0c796a83d26d079a47fdce667604df430598c7eabfa4e4dfd147033", size = 477610, upload-time = "2025-07-01T13:09:03.926Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
**Description:** Fix security vulnerability where ```QuerySQLDatabaseTool``` bypasses ```ignore_tables``` and ```include_tables``` restrictions. Previously, an LLM could craft SQL queries to access any table in the database, even those explicitly excluded via ```SQLDatabase(engine, ignore_tables=["sensitive_data"])```. This fix adds table validation using ```sqlglot``` to parse SQL queries and verify all referenced tables are in the allowed list before execution.

**Issue:** Fixes #617

**Dependencies:** ```sqlglot>=26.0.0,<27.0.0``` (added as test dependency only - imported within function per contribution guidelines)