### PR TITLE
refactor(tools): deprecate Azure AI Services / CogServices tools in community package

### DIFF
--- a/libs/community/langchain_community/agent_toolkits/azure_ai_services.py
+++ b/libs/community/langchain_community/agent_toolkits/azure_ai_services.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import List
 
+from langchain_core._api.deprecation import deprecated
 from langchain_core.tools import BaseTool
 from langchain_core.tools.base import BaseToolkit
 
@@ -14,6 +15,11 @@ from langchain_community.tools.azure_ai_services import (
 )
 
 
+@deprecated(
+    since="0.4.1",
+    removal="1.0",
+    alternative_import="langchain_azure_ai.tools.AIServicesToolkit",
+)
 class AzureAiServicesToolkit(BaseToolkit):
     """Toolkit for Azure AI Services."""
 

--- a/libs/community/langchain_community/tools/azure_ai_services/document_intelligence.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/document_intelligence.py
@@ -24,13 +24,17 @@ logger = logging.getLogger(__name__)
         "instead. See https://aka.ms/azureai/langchain for details."
     ),
     alternative_import="langchain_azure_ai.tools.AzureAIDocumentIntelligenceTool",
-    pending=True,
 )
 class AzureAiServicesDocumentIntelligenceTool(BaseTool):
     """Tool that queries the Azure AI Services Document Intelligence API.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/ai-services/document-intelligence/quickstarts/get-started-sdks-rest-api?view=doc-intel-4.0.0&pivots=programming-language-python
+
+    .. deprecated:: 0.4.1
+        This class is deprecated and will be removed in a future version.
+        Use AzureAIDocumentIntelligenceTool from the langchain-azure-ai package instead.
+        See https://aka.ms/azureai/langchain for details.
     """
 
     azure_ai_services_key: str = ""

--- a/libs/community/langchain_community/tools/azure_ai_services/document_intelligence.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/document_intelligence.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    removal="1.0",
+    removal="a future version",
     alternative_import="langchain_azure_ai.tools.AzureAIDocumentIntelligenceTool",
 )
 class AzureAiServicesDocumentIntelligenceTool(BaseTool):

--- a/libs/community/langchain_community/tools/azure_ai_services/document_intelligence.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/document_intelligence.py
@@ -18,8 +18,13 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    removal="a future version",
+    message=(
+        "This class is pending deprecation and may be removed in a future version. "
+        "Use AzureAIDocumentIntelligenceTool from the langchain-azure-ai package "
+        "instead. See https://aka.ms/azureai/langchain for details."
+    ),
     alternative_import="langchain_azure_ai.tools.AzureAIDocumentIntelligenceTool",
+    pending=True,
 )
 class AzureAiServicesDocumentIntelligenceTool(BaseTool):
     """Tool that queries the Azure AI Services Document Intelligence API.

--- a/libs/community/langchain_community/tools/azure_ai_services/document_intelligence.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/document_intelligence.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional
 
+from langchain_core._api.deprecation import deprecated
 from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools import BaseTool
 from langchain_core.utils import get_from_dict_or_env
@@ -15,6 +16,11 @@ from langchain_community.tools.azure_ai_services.utils import (
 logger = logging.getLogger(__name__)
 
 
+@deprecated(
+    since="0.4.1",
+    removal="1.0",
+    alternative_import="langchain_azure_ai.tools.AzureAIDocumentIntelligenceTool",
+)
 class AzureAiServicesDocumentIntelligenceTool(BaseTool):
     """Tool that queries the Azure AI Services Document Intelligence API.
 

--- a/libs/community/langchain_community/tools/azure_ai_services/document_intelligence.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/document_intelligence.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 @deprecated(
     since="0.4.1",
     message=(
-        "This class is pending deprecation and may be removed in a future version. "
+        "This class is deprecated and will be removed in a future version. "
         "Use AzureAIDocumentIntelligenceTool from the langchain-azure-ai package "
         "instead. See https://aka.ms/azureai/langchain for details."
     ),

--- a/libs/community/langchain_community/tools/azure_ai_services/image_analysis.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/image_analysis.py
@@ -24,7 +24,6 @@ logger = logging.getLogger(__name__)
         "instead. See https://aka.ms/azureai/langchain for details."
     ),
     alternative_import="langchain_azure_ai.tools.AzureAIImageAnalysisTool",
-    pending=True,
 )
 class AzureAiServicesImageAnalysisTool(BaseTool):
     """Tool that queries the Azure AI Services Image Analysis API.
@@ -43,6 +42,11 @@ class AzureAiServicesImageAnalysisTool(BaseTool):
     name (str): The name of the tool.
     description (str): A description of the tool,
         including its purpose and expected input.
+
+    .. deprecated:: 0.4.1
+        This class is deprecated and will be removed in a future version.
+        Use AzureAIImageAnalysisTool from the langchain-azure-ai package instead.
+        See https://aka.ms/azureai/langchain for details.
     """
 
     azure_ai_services_key: Optional[str] = None

--- a/libs/community/langchain_community/tools/azure_ai_services/image_analysis.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/image_analysis.py
@@ -18,8 +18,13 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    removal="a future version",
+    message=(
+        "This class is pending deprecation and may be removed in a future version. "
+        "Use AzureAIImageAnalysisTool from the langchain-azure-ai package "
+        "instead. See https://aka.ms/azureai/langchain for details."
+    ),
     alternative_import="langchain_azure_ai.tools.AzureAIImageAnalysisTool",
+    pending=True,
 )
 class AzureAiServicesImageAnalysisTool(BaseTool):
     """Tool that queries the Azure AI Services Image Analysis API.

--- a/libs/community/langchain_community/tools/azure_ai_services/image_analysis.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/image_analysis.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    removal="1.0",
+    removal="a future version",
     alternative_import="langchain_azure_ai.tools.AzureAIImageAnalysisTool",
 )
 class AzureAiServicesImageAnalysisTool(BaseTool):

--- a/libs/community/langchain_community/tools/azure_ai_services/image_analysis.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/image_analysis.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, Optional
 
+from langchain_core._api.deprecation import deprecated
 from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools import BaseTool
 from langchain_core.utils import get_from_dict_or_env
@@ -15,6 +16,11 @@ from langchain_community.tools.azure_ai_services.utils import (
 logger = logging.getLogger(__name__)
 
 
+@deprecated(
+    since="0.4.1",
+    removal="1.0",
+    alternative_import="langchain_azure_ai.tools.AzureAIImageAnalysisTool",
+)
 class AzureAiServicesImageAnalysisTool(BaseTool):
     """Tool that queries the Azure AI Services Image Analysis API.
 

--- a/libs/community/langchain_community/tools/azure_ai_services/image_analysis.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/image_analysis.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 @deprecated(
     since="0.4.1",
     message=(
-        "This class is pending deprecation and may be removed in a future version. "
+        "This class is deprecated and will be removed in a future version. "
         "Use AzureAIImageAnalysisTool from the langchain-azure-ai package "
         "instead. See https://aka.ms/azureai/langchain for details."
     ),

--- a/libs/community/langchain_community/tools/azure_ai_services/speech_to_text.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/speech_to_text.py
@@ -21,10 +21,7 @@ logger = logging.getLogger(__name__)
 @deprecated(
     since="0.4.1",
     removal="1.0",
-    message=(
-        "AzureAiServicesSpeechToTextTool has been deprecated. "
-        "Use `langchain-azure-ai` package instead."
-    ),
+    alternative_import="langchain_azure_ai.tools.AzureAISpeechToTextTool",
 )
 class AzureAiServicesSpeechToTextTool(BaseTool):
     """Tool that queries the Azure AI Services Speech to Text API.

--- a/libs/community/langchain_community/tools/azure_ai_services/speech_to_text.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/speech_to_text.py
@@ -26,13 +26,17 @@ logger = logging.getLogger(__name__)
         "instead. See https://aka.ms/azureai/langchain for details."
     ),
     alternative_import="langchain_azure_ai.tools.AzureAISpeechToTextTool",
-    pending=True,
 )
 class AzureAiServicesSpeechToTextTool(BaseTool):
     """Tool that queries the Azure AI Services Speech to Text API.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/ai-services/speech-service/get-started-speech-to-text?pivots=programming-language-python
+
+    .. deprecated:: 0.4.1
+        This class is deprecated and will be removed in a future version.
+        Use AzureAISpeechToTextTool from the langchain-azure-ai package instead.
+        See https://aka.ms/azureai/langchain for details.
     """
 
     azure_ai_services_key: str = ""

--- a/libs/community/langchain_community/tools/azure_ai_services/speech_to_text.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/speech_to_text.py
@@ -4,6 +4,7 @@ import logging
 import time
 from typing import Any, Dict, Optional
 
+from langchain_core._api.deprecation import deprecated
 from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools import BaseTool
 from langchain_core.utils import get_from_dict_or_env
@@ -17,6 +18,14 @@ from langchain_community.tools.azure_ai_services.utils import (
 logger = logging.getLogger(__name__)
 
 
+@deprecated(
+    since="0.4.1",
+    removal="1.0",
+    message=(
+        "AzureAiServicesSpeechToTextTool has been deprecated. "
+        "Use `langchain-azure-ai` package instead."
+    ),
+)
 class AzureAiServicesSpeechToTextTool(BaseTool):
     """Tool that queries the Azure AI Services Speech to Text API.
 

--- a/libs/community/langchain_community/tools/azure_ai_services/speech_to_text.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/speech_to_text.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 @deprecated(
     since="0.4.1",
     message=(
-        "This class is pending deprecation and may be removed in a future version. "
+        "This class is deprecated and will be removed in a future version. "
         "Use AzureAISpeechToTextTool from the langchain-azure-ai package "
         "instead. See https://aka.ms/azureai/langchain for details."
     ),

--- a/libs/community/langchain_community/tools/azure_ai_services/speech_to_text.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/speech_to_text.py
@@ -20,7 +20,7 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    removal="1.0",
+    removal="a future version",
     alternative_import="langchain_azure_ai.tools.AzureAISpeechToTextTool",
 )
 class AzureAiServicesSpeechToTextTool(BaseTool):

--- a/libs/community/langchain_community/tools/azure_ai_services/speech_to_text.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/speech_to_text.py
@@ -20,8 +20,13 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    removal="a future version",
+    message=(
+        "This class is pending deprecation and may be removed in a future version. "
+        "Use AzureAISpeechToTextTool from the langchain-azure-ai package "
+        "instead. See https://aka.ms/azureai/langchain for details."
+    ),
     alternative_import="langchain_azure_ai.tools.AzureAISpeechToTextTool",
+    pending=True,
 )
 class AzureAiServicesSpeechToTextTool(BaseTool):
     """Tool that queries the Azure AI Services Speech to Text API.

--- a/libs/community/langchain_community/tools/azure_ai_services/text_analytics_for_health.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/text_analytics_for_health.py
@@ -20,13 +20,17 @@ logger = logging.getLogger(__name__)
         "instead. See https://aka.ms/azureai/langchain for details."
     ),
     alternative_import="langchain_azure_ai.tools.AzureAITextAnalyticsHealthTool",
-    pending=True,
 )
 class AzureAiServicesTextAnalyticsForHealthTool(BaseTool):
     """Tool that queries the Azure AI Services Text Analytics for Health API.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/ai-services/language-service/text-analytics-for-health/quickstart?pivots=programming-language-python
+
+    .. deprecated:: 0.4.1
+        This class is deprecated and will be removed in a future version.
+        Use AzureAITextAnalyticsHealthTool from the langchain-azure-ai package instead.
+        See https://aka.ms/azureai/langchain for details.
     """
 
     azure_ai_services_key: str = ""

--- a/libs/community/langchain_community/tools/azure_ai_services/text_analytics_for_health.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/text_analytics_for_health.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, Optional
 
+from langchain_core._api.deprecation import deprecated
 from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools import BaseTool
 from langchain_core.utils import get_from_dict_or_env
@@ -11,6 +12,11 @@ from pydantic import model_validator
 logger = logging.getLogger(__name__)
 
 
+@deprecated(
+    since="0.4.1",
+    removal="1.0",
+    alternative_import="langchain_azure_ai.tools.AzureAITextAnalyticsHealthTool",
+)
 class AzureAiServicesTextAnalyticsForHealthTool(BaseTool):
     """Tool that queries the Azure AI Services Text Analytics for Health API.
 

--- a/libs/community/langchain_community/tools/azure_ai_services/text_analytics_for_health.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/text_analytics_for_health.py
@@ -14,8 +14,13 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    removal="a future version",
+    message=(
+        "This class is pending deprecation and may be removed in a future version. "
+        "Use AzureAITextAnalyticsHealthTool from the langchain-azure-ai package "
+        "instead. See https://aka.ms/azureai/langchain for details."
+    ),
     alternative_import="langchain_azure_ai.tools.AzureAITextAnalyticsHealthTool",
+    pending=True,
 )
 class AzureAiServicesTextAnalyticsForHealthTool(BaseTool):
     """Tool that queries the Azure AI Services Text Analytics for Health API.

--- a/libs/community/langchain_community/tools/azure_ai_services/text_analytics_for_health.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/text_analytics_for_health.py
@@ -14,7 +14,7 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    removal="1.0",
+    removal="a future version",
     alternative_import="langchain_azure_ai.tools.AzureAITextAnalyticsHealthTool",
 )
 class AzureAiServicesTextAnalyticsForHealthTool(BaseTool):

--- a/libs/community/langchain_community/tools/azure_ai_services/text_analytics_for_health.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/text_analytics_for_health.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 @deprecated(
     since="0.4.1",
     message=(
-        "This class is pending deprecation and may be removed in a future version. "
+        "This class is deprecated and will be removed in a future version. "
         "Use AzureAITextAnalyticsHealthTool from the langchain-azure-ai package "
         "instead. See https://aka.ms/azureai/langchain for details."
     ),

--- a/libs/community/langchain_community/tools/azure_ai_services/text_to_speech.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/text_to_speech.py
@@ -15,8 +15,13 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    removal="a future version",
+    message=(
+        "This class is pending deprecation and may be removed in a future version. "
+        "Use AzureAITextToSpeechTool from the langchain-azure-ai package "
+        "instead. See https://aka.ms/azureai/langchain for details."
+    ),
     alternative_import="langchain_azure_ai.tools.AzureAITextToSpeechTool",
+    pending=True,
 )
 class AzureAiServicesTextToSpeechTool(BaseTool):
     """Tool that queries the Azure AI Services Text to Speech API.

--- a/libs/community/langchain_community/tools/azure_ai_services/text_to_speech.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/text_to_speech.py
@@ -16,10 +16,7 @@ logger = logging.getLogger(__name__)
 @deprecated(
     since="0.4.1",
     removal="1.0",
-    message=(
-        "AzureAiServicesTextToSpeechTool has been deprecated. "
-        "Use `langchain-azure-ai` package instead."
-    ),
+    alternative_import="langchain_azure_ai.tools.AzureAITextToSpeechTool",
 )
 class AzureAiServicesTextToSpeechTool(BaseTool):
     """Tool that queries the Azure AI Services Text to Speech API.

--- a/libs/community/langchain_community/tools/azure_ai_services/text_to_speech.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/text_to_speech.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    removal="1.0",
+    removal="a future version",
     alternative_import="langchain_azure_ai.tools.AzureAITextToSpeechTool",
 )
 class AzureAiServicesTextToSpeechTool(BaseTool):

--- a/libs/community/langchain_community/tools/azure_ai_services/text_to_speech.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/text_to_speech.py
@@ -21,13 +21,17 @@ logger = logging.getLogger(__name__)
         "instead. See https://aka.ms/azureai/langchain for details."
     ),
     alternative_import="langchain_azure_ai.tools.AzureAITextToSpeechTool",
-    pending=True,
 )
 class AzureAiServicesTextToSpeechTool(BaseTool):
     """Tool that queries the Azure AI Services Text to Speech API.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/ai-services/speech-service/get-started-text-to-speech?pivots=programming-language-python
+
+    .. deprecated:: 0.4.1
+        This class is deprecated and will be removed in a future version.
+        Use AzureAITextToSpeechTool from the langchain-azure-ai package instead.
+        See https://aka.ms/azureai/langchain for details.
     """
 
     name: str = "azure_ai_services_text_to_speech"

--- a/libs/community/langchain_community/tools/azure_ai_services/text_to_speech.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/text_to_speech.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 @deprecated(
     since="0.4.1",
     message=(
-        "This class is pending deprecation and may be removed in a future version. "
+        "This class is deprecated and will be removed in a future version. "
         "Use AzureAITextToSpeechTool from the langchain-azure-ai package "
         "instead. See https://aka.ms/azureai/langchain for details."
     ),

--- a/libs/community/langchain_community/tools/azure_ai_services/text_to_speech.py
+++ b/libs/community/langchain_community/tools/azure_ai_services/text_to_speech.py
@@ -4,6 +4,7 @@ import logging
 import tempfile
 from typing import Any, Dict, Optional
 
+from langchain_core._api.deprecation import deprecated
 from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools import BaseTool
 from langchain_core.utils import get_from_dict_or_env
@@ -12,6 +13,14 @@ from pydantic import model_validator
 logger = logging.getLogger(__name__)
 
 
+@deprecated(
+    since="0.4.1",
+    removal="1.0",
+    message=(
+        "AzureAiServicesTextToSpeechTool has been deprecated. "
+        "Use `langchain-azure-ai` package instead."
+    ),
+)
 class AzureAiServicesTextToSpeechTool(BaseTool):
     """Tool that queries the Azure AI Services Text to Speech API.
 

--- a/libs/community/langchain_community/tools/azure_cognitive_services/form_recognizer.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/form_recognizer.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, List, Optional
 
+from langchain_core._api import deprecated
 from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools import BaseTool
 from langchain_core.utils import get_from_dict_or_env
@@ -15,8 +16,25 @@ from langchain_community.tools.azure_cognitive_services.utils import (
 logger = logging.getLogger(__name__)
 
 
+@deprecated(
+    since="0.4.1",
+    message=(
+        "This tool is deprecated and will be removed in a future version. "
+        "Please use AzureAIDocumentIntelligenceTool from the langchain-azure-ai "
+        "package instead. "
+        "See https://aka.ms/azureai/langchain for details."
+    ),
+    alternative=(
+        "from langchain_azure_ai.tools import AzureAIDocumentIntelligenceTool"
+    ),
+    pending=False,
+)
 class AzureCogsFormRecognizerTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Form Recognizer API.
+
+    .. deprecated:: 0.4.1
+        This tool is deprecated. Use
+        :class:`langchain_azure_ai.tools.AzureAIDocumentIntelligenceTool` instead.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/applied-ai-services/form-recognizer/quickstarts/get-started-sdks-rest-api?view=form-recog-3.0.0&pivots=programming-language-python

--- a/libs/community/langchain_community/tools/azure_cognitive_services/form_recognizer.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/form_recognizer.py
@@ -18,23 +18,11 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    message=(
-        "This tool is deprecated and will be removed in a future version. "
-        "Please use AzureAIDocumentIntelligenceTool from the langchain-azure-ai "
-        "package instead. "
-        "See https://aka.ms/azureai/langchain for details."
-    ),
-    alternative=(
-        "from langchain_azure_ai.tools import AzureAIDocumentIntelligenceTool"
-    ),
-    pending=False,
+    removal="a future version",
+    alternative_import="langchain_azure_ai.tools.AzureAIDocumentIntelligenceTool",
 )
 class AzureCogsFormRecognizerTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Form Recognizer API.
-
-    .. deprecated:: 0.4.1
-        This tool is deprecated. Use
-        :class:`langchain_azure_ai.tools.AzureAIDocumentIntelligenceTool` instead.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/applied-ai-services/form-recognizer/quickstarts/get-started-sdks-rest-api?view=form-recog-3.0.0&pivots=programming-language-python

--- a/libs/community/langchain_community/tools/azure_cognitive_services/form_recognizer.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/form_recognizer.py
@@ -18,8 +18,13 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    removal="a future version",
+    message=(
+        "This class is pending deprecation and may be removed in a future version. "
+        "Use AzureAIDocumentIntelligenceTool from the langchain-azure-ai package "
+        "instead. See https://aka.ms/azureai/langchain for details."
+    ),
     alternative_import="langchain_azure_ai.tools.AzureAIDocumentIntelligenceTool",
+    pending=True,
 )
 class AzureCogsFormRecognizerTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Form Recognizer API.

--- a/libs/community/langchain_community/tools/azure_cognitive_services/form_recognizer.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/form_recognizer.py
@@ -24,13 +24,17 @@ logger = logging.getLogger(__name__)
         "instead. See https://aka.ms/azureai/langchain for details."
     ),
     alternative_import="langchain_azure_ai.tools.AzureAIDocumentIntelligenceTool",
-    pending=True,
 )
 class AzureCogsFormRecognizerTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Form Recognizer API.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/applied-ai-services/form-recognizer/quickstarts/get-started-sdks-rest-api?view=form-recog-3.0.0&pivots=programming-language-python
+
+    .. deprecated:: 0.4.1
+        This class is deprecated and will be removed in a future version.
+        Use AzureAIDocumentIntelligenceTool from the langchain-azure-ai package instead.
+        See https://aka.ms/azureai/langchain for details.
     """
 
     azure_cogs_key: str = ""

--- a/libs/community/langchain_community/tools/azure_cognitive_services/form_recognizer.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/form_recognizer.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 @deprecated(
     since="0.4.1",
     message=(
-        "This class is pending deprecation and may be removed in a future version. "
+        "This class is deprecated and will be removed in a future version. "
         "Use AzureAIDocumentIntelligenceTool from the langchain-azure-ai package "
         "instead. See https://aka.ms/azureai/langchain for details."
     ),

--- a/libs/community/langchain_community/tools/azure_cognitive_services/image_analysis.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/image_analysis.py
@@ -18,8 +18,13 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    removal="a future version",
+    message=(
+        "This class is pending deprecation and may be removed in a future version. "
+        "Use AzureAIImageAnalysisTool from the langchain-azure-ai package "
+        "instead. See https://aka.ms/azureai/langchain for details."
+    ),
     alternative_import="langchain_azure_ai.tools.AzureAIImageAnalysisTool",
+    pending=True,
 )
 class AzureCogsImageAnalysisTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Image Analysis API.

--- a/libs/community/langchain_community/tools/azure_cognitive_services/image_analysis.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/image_analysis.py
@@ -24,13 +24,17 @@ logger = logging.getLogger(__name__)
         "instead. See https://aka.ms/azureai/langchain for details."
     ),
     alternative_import="langchain_azure_ai.tools.AzureAIImageAnalysisTool",
-    pending=True,
 )
 class AzureCogsImageAnalysisTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Image Analysis API.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/cognitive-services/computer-vision/quickstarts-sdk/image-analysis-client-library-40
+
+    .. deprecated:: 0.4.1
+        This class is deprecated and will be removed in a future version.
+        Use AzureAIImageAnalysisTool from the langchain-azure-ai package instead.
+        See https://aka.ms/azureai/langchain for details.
     """
 
     azure_cogs_key: str = ""

--- a/libs/community/langchain_community/tools/azure_cognitive_services/image_analysis.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/image_analysis.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, Optional
 
+from langchain_core._api import deprecated
 from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools import BaseTool
 from langchain_core.utils import get_from_dict_or_env
@@ -15,8 +16,23 @@ from langchain_community.tools.azure_cognitive_services.utils import (
 logger = logging.getLogger(__name__)
 
 
+@deprecated(
+    since="0.4.1",
+    message=(
+        "This tool is deprecated and will be removed in a future version. "
+        "Please use AzureAIImageAnalysisTool from the langchain-azure-ai "
+        "package instead. "
+        "See https://aka.ms/azureai/langchain for details."
+    ),
+    alternative="from langchain_azure_ai.tools import AzureAIImageAnalysisTool",
+    pending=False,
+)
 class AzureCogsImageAnalysisTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Image Analysis API.
+
+    .. deprecated:: 0.4.1
+        This tool is deprecated. Use
+        :class:`langchain_azure_ai.tools.AzureAIImageAnalysisTool` instead.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/cognitive-services/computer-vision/quickstarts-sdk/image-analysis-client-library-40

--- a/libs/community/langchain_community/tools/azure_cognitive_services/image_analysis.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/image_analysis.py
@@ -19,7 +19,7 @@ logger = logging.getLogger(__name__)
 @deprecated(
     since="0.4.1",
     message=(
-        "This class is pending deprecation and may be removed in a future version. "
+        "This class is deprecated and will be removed in a future version. "
         "Use AzureAIImageAnalysisTool from the langchain-azure-ai package "
         "instead. See https://aka.ms/azureai/langchain for details."
     ),

--- a/libs/community/langchain_community/tools/azure_cognitive_services/image_analysis.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/image_analysis.py
@@ -18,21 +18,11 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    message=(
-        "This tool is deprecated and will be removed in a future version. "
-        "Please use AzureAIImageAnalysisTool from the langchain-azure-ai "
-        "package instead. "
-        "See https://aka.ms/azureai/langchain for details."
-    ),
-    alternative="from langchain_azure_ai.tools import AzureAIImageAnalysisTool",
-    pending=False,
+    removal="a future version",
+    alternative_import="langchain_azure_ai.tools.AzureAIImageAnalysisTool",
 )
 class AzureCogsImageAnalysisTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Image Analysis API.
-
-    .. deprecated:: 0.4.1
-        This tool is deprecated. Use
-        :class:`langchain_azure_ai.tools.AzureAIImageAnalysisTool` instead.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/cognitive-services/computer-vision/quickstarts-sdk/image-analysis-client-library-40

--- a/libs/community/langchain_community/tools/azure_cognitive_services/speech2text.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/speech2text.py
@@ -20,8 +20,13 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    removal="a future version",
+    message=(
+        "This class is pending deprecation and may be removed in a future version. "
+        "Use AzureAISpeechToTextTool from the langchain-azure-ai package "
+        "instead. See https://aka.ms/azureai/langchain for details."
+    ),
     alternative_import="langchain_azure_ai.tools.AzureAISpeechToTextTool",
+    pending=True,
 )
 class AzureCogsSpeech2TextTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Speech2Text API.

--- a/libs/community/langchain_community/tools/azure_cognitive_services/speech2text.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/speech2text.py
@@ -20,21 +20,11 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    message=(
-        "This tool is deprecated and will be removed in a future version. "
-        "Please use AzureAISpeechToTextTool from the langchain-azure-ai "
-        "package instead. "
-        "See https://aka.ms/azureai/langchain for details."
-    ),
-    alternative="from langchain_azure_ai.tools import AzureAISpeechToTextTool",
-    pending=False,
+    removal="a future version",
+    alternative_import="langchain_azure_ai.tools.AzureAISpeechToTextTool",
 )
 class AzureCogsSpeech2TextTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Speech2Text API.
-
-    .. deprecated:: 0.4.1
-        This tool is deprecated. Use
-        :class:`langchain_azure_ai.tools.AzureAISpeechToTextTool` instead.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/get-started-speech-to-text?pivots=programming-language-python

--- a/libs/community/langchain_community/tools/azure_cognitive_services/speech2text.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/speech2text.py
@@ -26,13 +26,17 @@ logger = logging.getLogger(__name__)
         "instead. See https://aka.ms/azureai/langchain for details."
     ),
     alternative_import="langchain_azure_ai.tools.AzureAISpeechToTextTool",
-    pending=True,
 )
 class AzureCogsSpeech2TextTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Speech2Text API.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/get-started-speech-to-text?pivots=programming-language-python
+
+    .. deprecated:: 0.4.1
+        This class is deprecated and will be removed in a future version.
+        Use AzureAISpeechToTextTool from the langchain-azure-ai package instead.
+        See https://aka.ms/azureai/langchain for details.
     """
 
     azure_cogs_key: str = ""

--- a/libs/community/langchain_community/tools/azure_cognitive_services/speech2text.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/speech2text.py
@@ -21,7 +21,7 @@ logger = logging.getLogger(__name__)
 @deprecated(
     since="0.4.1",
     message=(
-        "This class is pending deprecation and may be removed in a future version. "
+        "This class is deprecated and will be removed in a future version. "
         "Use AzureAISpeechToTextTool from the langchain-azure-ai package "
         "instead. See https://aka.ms/azureai/langchain for details."
     ),

--- a/libs/community/langchain_community/tools/azure_cognitive_services/speech2text.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/speech2text.py
@@ -4,6 +4,7 @@ import logging
 import time
 from typing import Any, Dict, Optional
 
+from langchain_core._api import deprecated
 from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools import BaseTool
 from langchain_core.utils import get_from_dict_or_env
@@ -17,8 +18,23 @@ from langchain_community.tools.azure_cognitive_services.utils import (
 logger = logging.getLogger(__name__)
 
 
+@deprecated(
+    since="0.4.1",
+    message=(
+        "This tool is deprecated and will be removed in a future version. "
+        "Please use AzureAISpeechToTextTool from the langchain-azure-ai "
+        "package instead. "
+        "See https://aka.ms/azureai/langchain for details."
+    ),
+    alternative="from langchain_azure_ai.tools import AzureAISpeechToTextTool",
+    pending=False,
+)
 class AzureCogsSpeech2TextTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Speech2Text API.
+
+    .. deprecated:: 0.4.1
+        This tool is deprecated. Use
+        :class:`langchain_azure_ai.tools.AzureAISpeechToTextTool` instead.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/get-started-speech-to-text?pivots=programming-language-python

--- a/libs/community/langchain_community/tools/azure_cognitive_services/text2speech.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/text2speech.py
@@ -21,13 +21,17 @@ logger = logging.getLogger(__name__)
         "instead. See https://aka.ms/azureai/langchain for details."
     ),
     alternative_import="langchain_azure_ai.tools.AzureAITextToSpeechTool",
-    pending=True,
 )
 class AzureCogsText2SpeechTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Text2Speech API.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/get-started-text-to-speech?pivots=programming-language-python
+
+    .. deprecated:: 0.4.1
+        This class is deprecated and will be removed in a future version.
+        Use AzureAITextToSpeechTool from the langchain-azure-ai package instead.
+        See https://aka.ms/azureai/langchain for details.
     """
 
     azure_cogs_key: str = ""

--- a/libs/community/langchain_community/tools/azure_cognitive_services/text2speech.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/text2speech.py
@@ -4,6 +4,7 @@ import logging
 import tempfile
 from typing import Any, Dict, Optional
 
+from langchain_core._api import deprecated
 from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools import BaseTool
 from langchain_core.utils import get_from_dict_or_env
@@ -12,8 +13,23 @@ from pydantic import model_validator
 logger = logging.getLogger(__name__)
 
 
+@deprecated(
+    since="0.4.1",
+    message=(
+        "This tool is deprecated and will be removed in a future version. "
+        "Please use AzureAITextToSpeechTool from the langchain-azure-ai "
+        "package instead. "
+        "See https://aka.ms/azureai/langchain for details."
+    ),
+    alternative="from langchain_azure_ai.tools import AzureAITextToSpeechTool",
+    pending=False,
+)
 class AzureCogsText2SpeechTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Text2Speech API.
+
+    .. deprecated:: 0.4.1
+        This tool is deprecated. Use
+        :class:`langchain_azure_ai.tools.AzureAITextToSpeechTool` instead.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/get-started-text-to-speech?pivots=programming-language-python

--- a/libs/community/langchain_community/tools/azure_cognitive_services/text2speech.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/text2speech.py
@@ -15,21 +15,11 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    message=(
-        "This tool is deprecated and will be removed in a future version. "
-        "Please use AzureAITextToSpeechTool from the langchain-azure-ai "
-        "package instead. "
-        "See https://aka.ms/azureai/langchain for details."
-    ),
-    alternative="from langchain_azure_ai.tools import AzureAITextToSpeechTool",
-    pending=False,
+    removal="a future version",
+    alternative_import="langchain_azure_ai.tools.AzureAITextToSpeechTool",
 )
 class AzureCogsText2SpeechTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Text2Speech API.
-
-    .. deprecated:: 0.4.1
-        This tool is deprecated. Use
-        :class:`langchain_azure_ai.tools.AzureAITextToSpeechTool` instead.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/cognitive-services/speech-service/get-started-text-to-speech?pivots=programming-language-python

--- a/libs/community/langchain_community/tools/azure_cognitive_services/text2speech.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/text2speech.py
@@ -16,7 +16,7 @@ logger = logging.getLogger(__name__)
 @deprecated(
     since="0.4.1",
     message=(
-        "This class is pending deprecation and may be removed in a future version. "
+        "This class is deprecated and will be removed in a future version. "
         "Use AzureAITextToSpeechTool from the langchain-azure-ai package "
         "instead. See https://aka.ms/azureai/langchain for details."
     ),

--- a/libs/community/langchain_community/tools/azure_cognitive_services/text2speech.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/text2speech.py
@@ -15,8 +15,13 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    removal="a future version",
+    message=(
+        "This class is pending deprecation and may be removed in a future version. "
+        "Use AzureAITextToSpeechTool from the langchain-azure-ai package "
+        "instead. See https://aka.ms/azureai/langchain for details."
+    ),
     alternative_import="langchain_azure_ai.tools.AzureAITextToSpeechTool",
+    pending=True,
 )
 class AzureCogsText2SpeechTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Text2Speech API.

--- a/libs/community/langchain_community/tools/azure_cognitive_services/text_analytics_health.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/text_analytics_health.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import logging
 from typing import Any, Dict, Optional
 
+from langchain_core._api import deprecated
 from langchain_core.callbacks import CallbackManagerForToolRun
 from langchain_core.tools import BaseTool
 from langchain_core.utils import get_from_dict_or_env
@@ -11,8 +12,25 @@ from pydantic import model_validator
 logger = logging.getLogger(__name__)
 
 
+@deprecated(
+    since="0.4.1",
+    message=(
+        "This tool is deprecated and will be removed in a future version. "
+        "Please use AzureAITextAnalyticsHealthTool from the langchain-azure-ai "
+        "package instead. "
+        "See https://aka.ms/azureai/langchain for details."
+    ),
+    alternative=(
+        "from langchain_azure_ai.tools import AzureAITextAnalyticsHealthTool"
+    ),
+    pending=False,
+)
 class AzureCogsTextAnalyticsHealthTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Text Analytics for Health API.
+
+    .. deprecated:: 0.4.1
+        This tool is deprecated. Use
+        :class:`langchain_azure_ai.tools.AzureAITextAnalyticsHealthTool` instead.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/ai-services/language-service/text-analytics-for-health/quickstart?tabs=windows&pivots=programming-language-python

--- a/libs/community/langchain_community/tools/azure_cognitive_services/text_analytics_health.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/text_analytics_health.py
@@ -20,13 +20,17 @@ logger = logging.getLogger(__name__)
         "instead. See https://aka.ms/azureai/langchain for details."
     ),
     alternative_import="langchain_azure_ai.tools.AzureAITextAnalyticsHealthTool",
-    pending=True,
 )
 class AzureCogsTextAnalyticsHealthTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Text Analytics for Health API.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/ai-services/language-service/text-analytics-for-health/quickstart?tabs=windows&pivots=programming-language-python
+
+    .. deprecated:: 0.4.1
+        This class is deprecated and will be removed in a future version.
+        Use AzureAITextAnalyticsHealthTool from the langchain-azure-ai package instead.
+        See https://aka.ms/azureai/langchain for details.
     """
 
     azure_cogs_key: str = ""

--- a/libs/community/langchain_community/tools/azure_cognitive_services/text_analytics_health.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/text_analytics_health.py
@@ -14,23 +14,11 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    message=(
-        "This tool is deprecated and will be removed in a future version. "
-        "Please use AzureAITextAnalyticsHealthTool from the langchain-azure-ai "
-        "package instead. "
-        "See https://aka.ms/azureai/langchain for details."
-    ),
-    alternative=(
-        "from langchain_azure_ai.tools import AzureAITextAnalyticsHealthTool"
-    ),
-    pending=False,
+    removal="a future version",
+    alternative_import="langchain_azure_ai.tools.AzureAITextAnalyticsHealthTool",
 )
 class AzureCogsTextAnalyticsHealthTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Text Analytics for Health API.
-
-    .. deprecated:: 0.4.1
-        This tool is deprecated. Use
-        :class:`langchain_azure_ai.tools.AzureAITextAnalyticsHealthTool` instead.
 
     In order to set this up, follow instructions at:
     https://learn.microsoft.com/en-us/azure/ai-services/language-service/text-analytics-for-health/quickstart?tabs=windows&pivots=programming-language-python

--- a/libs/community/langchain_community/tools/azure_cognitive_services/text_analytics_health.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/text_analytics_health.py
@@ -14,8 +14,13 @@ logger = logging.getLogger(__name__)
 
 @deprecated(
     since="0.4.1",
-    removal="a future version",
+    message=(
+        "This class is pending deprecation and may be removed in a future version. "
+        "Use AzureAITextAnalyticsHealthTool from the langchain-azure-ai package "
+        "instead. See https://aka.ms/azureai/langchain for details."
+    ),
     alternative_import="langchain_azure_ai.tools.AzureAITextAnalyticsHealthTool",
+    pending=True,
 )
 class AzureCogsTextAnalyticsHealthTool(BaseTool):
     """Tool that queries the Azure Cognitive Services Text Analytics for Health API.

--- a/libs/community/langchain_community/tools/azure_cognitive_services/text_analytics_health.py
+++ b/libs/community/langchain_community/tools/azure_cognitive_services/text_analytics_health.py
@@ -15,7 +15,7 @@ logger = logging.getLogger(__name__)
 @deprecated(
     since="0.4.1",
     message=(
-        "This class is pending deprecation and may be removed in a future version. "
+        "This class is deprecated and will be removed in a future version. "
         "Use AzureAITextAnalyticsHealthTool from the langchain-azure-ai package "
         "instead. See https://aka.ms/azureai/langchain for details."
     ),

--- a/libs/community/tests/unit_tests/tools/azure_ai_services/test_image_analysis.py
+++ b/libs/community/tests/unit_tests/tools/azure_ai_services/test_image_analysis.py
@@ -1,5 +1,6 @@
 """Tests for the Azure AI Services Image Analysis Tool."""
 
+import warnings
 from pathlib import Path
 from typing import Any
 
@@ -23,9 +24,13 @@ def test_content_safety(mocker: Any) -> None:
     key = "key"
     endpoint = "endpoint"
 
-    tool = AzureAiServicesImageAnalysisTool(
-        azure_ai_services_key=key, azure_ai_services_endpoint=endpoint
-    )
+    with warnings.catch_warnings(record=True) as caught_warnings:
+        warnings.simplefilter("always")
+        tool = AzureAiServicesImageAnalysisTool(
+            azure_ai_services_key=key, azure_ai_services_endpoint=endpoint
+        )
+        assert any(issubclass(w.category, DeprecationWarning) for w in caught_warnings)
+
     assert tool.azure_ai_services_key == key
     assert tool.azure_ai_services_endpoint == endpoint
 
@@ -42,11 +47,13 @@ def test_local_image_analysis(mocker: Any) -> None:
         return_value="local",
     )
 
-    tool = AzureAiServicesImageAnalysisTool(
-        azure_ai_services_key=key,
-        azure_ai_services_endpoint=endpoint,
-        visual_features=["CAPTION"],
-    )
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        tool = AzureAiServicesImageAnalysisTool(
+            azure_ai_services_key=key,
+            azure_ai_services_endpoint=endpoint,
+            visual_features=["CAPTION"],
+        )
 
     mock_content_client = mocker.Mock()
     mock_content_client.analyze.return_value = mocker.Mock()
@@ -80,11 +87,13 @@ def test_local_image_different_features(mocker: Any) -> None:
         return_value="local",
     )
 
-    tool = AzureAiServicesImageAnalysisTool(
-        azure_ai_services_key=key,
-        azure_ai_services_endpoint=endpoint,
-        visual_features=["PEOPLE", "CAPTION", "SMARTCROPS"],
-    )
+    with warnings.catch_warnings(record=True):
+        warnings.simplefilter("always")
+        tool = AzureAiServicesImageAnalysisTool(
+            azure_ai_services_key=key,
+            azure_ai_services_endpoint=endpoint,
+            visual_features=["PEOPLE", "CAPTION", "SMARTCROPS"],
+        )
 
     mock_content_client = mocker.Mock()
     mock_content_client.analyze.return_value = mocker.Mock()


### PR DESCRIPTION
This pull request introduces deprecation warnings for several Azure AI and Azure Cognitive Services tool classes in the `langchain_community` package, guiding users to migrate to the new `langchain-azure-ai` package. It also updates related unit tests to check for deprecation warnings. These changes are aimed at informing users about the upcoming removal of these classes and providing clear migration paths.
