### PR TITLE
ci(infra): harden Dependabot version-bound preservation

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -26,6 +26,14 @@ updates:
     directory: "/libs/community"
     schedule:
       interval: "monthly"
+    versioning-strategy: increase
+    ignore:
+      - dependency-name: "langchain-core"
+      - dependency-name: "langchain"
+      - dependency-name: "langchain-classic"
+      - dependency-name: "langchain-text-splitters"
+      - dependency-name: "langchain-tests"
+      - dependency-name: "langchain-model-profiles"
     groups:
       minor-and-patch:
         patterns:


### PR DESCRIPTION
## Description
Ports langchain-ai/langchain#37510 to this repo. Dependabot has been
stripping upper/lower bounds from internal langchain-* deps in partner
pyproject.toml files. Adds `versioning-strategy: increase` to every uv
ecosystem block so future bumps move the lower bound in place, and
ignores workspace-internal langchain-* packages.

Scope is intentionally limited to the CI config — existing pyproject.toml
bounds in this repo should be audited separately if/when desired.

## Release Note
none

## Test Plan
- [ ] Confirm `.github/dependabot.yml` still parses as valid YAML
- [ ] Confirm new keys only apply to `uv` ecosystem blocks